### PR TITLE
Make Challenge model expires at nullable for totp and adjust test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import java.io.FileOutputStream
 import java.util.Properties
 
 group = "com.workos"
-version = "2.1.2"
+version = "2.1.3"
 
 if (!project.hasProperty("release")) {
   version = "$version-SNAPSHOT"

--- a/src/main/kotlin/com/workos/mfa/models/Challenge.kt
+++ b/src/main/kotlin/com/workos/mfa/models/Challenge.kt
@@ -26,7 +26,7 @@ data class Challenge
 
   @JvmField
   @JsonProperty("expires_at")
-  val expiresAt: String,
+  val expiresAt: String?,
 
   @JvmField
   @JsonProperty("code")

--- a/src/test/kotlin/com/workos/test/mfa/MfaApiTest.kt
+++ b/src/test/kotlin/com/workos/test/mfa/MfaApiTest.kt
@@ -178,7 +178,6 @@ class MfaApiTest : TestBase() {
           "authentication_factor_id": "auth_factor_1234",
           "code": "12345",
           "created_at": "2022-03-15T20:39:19.892Z",
-          "expires_at": "2022-03-15T21:39:19.892Z",
           "id": "auth_challenge_1234",
           "object": "authentication_challenge",
           "updated_at": "2022-03-15T20:39:19.892Z"


### PR DESCRIPTION
Make Challenge model expires at nullable for totp and adjust test. Totp challenge does not return "expires_at" and throws an error currently. 