### PR TITLE
Ensure Dokka runs after Javadoc task

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -82,6 +82,10 @@ tasks.named("build") {
   finalizedBy("dokkaJavadoc")
 }
 
+tasks.named("javadoc") {
+  finalizedBy("dokkaJavadoc")
+}
+
 tasks.dokkaJavadoc.configure {
   outputDirectory.set(buildDir.resolve("docs/javadoc"))
   dokkaSourceSets {


### PR DESCRIPTION
The Javadocs are not currently being published to Maven Central correctly.