### PR TITLE
Ensure that error responses are mapped correctly

### DIFF
--- a/src/main/kotlin/com/workos/WorkOS.kt
+++ b/src/main/kotlin/com/workos/WorkOS.kt
@@ -203,16 +203,16 @@ class WorkOS(
   }
 
   private fun sendRequest(request: Request): String {
-    val (_, response, result) = request.responseString()
+    val (_, response) = request.responseString()
 
-    val (payload) = result
+    var payload = String(response.data)
 
-    if (response.statusCode >= 400) {
-      handleResponseError(response, payload ?: "{}")
+    if (payload.isEmpty()) {
+      payload = "{}"
     }
 
-    if (payload == null) {
-      throw Exception("Path ${response.url.path} returned an empty response.")
+    if (response.statusCode >= 400) {
+      handleResponseError(response, payload)
     }
 
     return payload

--- a/src/main/kotlin/com/workos/common/exceptions/GenericServerException.kt
+++ b/src/main/kotlin/com/workos/common/exceptions/GenericServerException.kt
@@ -9,6 +9,6 @@ package com.workos.common.exceptions
  */
 class GenericServerException(
   override val message: String?,
-  private val status: Int,
-  private val requestId: String
+  val status: Int,
+  val requestId: String
 ) : Exception(message)

--- a/src/main/kotlin/com/workos/common/exceptions/NotFoundException.kt
+++ b/src/main/kotlin/com/workos/common/exceptions/NotFoundException.kt
@@ -8,7 +8,7 @@ package com.workos.common.exceptions
  */
 class NotFoundException(
   private val path: String,
-  private val requestId: String,
+  val requestId: String,
 ) : Exception("NotFoundException") {
-  private val status = 404
+  val status = 404
 }

--- a/src/main/kotlin/com/workos/common/exceptions/UnauthorizedException.kt
+++ b/src/main/kotlin/com/workos/common/exceptions/UnauthorizedException.kt
@@ -8,7 +8,7 @@ package com.workos.common.exceptions
  */
 class UnauthorizedException(
   override val message: String?,
-  private val requestId: String
+  val requestId: String
 ) : Exception(message) {
-  private val status = 401
+  val status = 401
 }

--- a/src/main/kotlin/com/workos/common/exceptions/UnprocessableEntityException.kt
+++ b/src/main/kotlin/com/workos/common/exceptions/UnprocessableEntityException.kt
@@ -11,9 +11,9 @@ import com.workos.common.http.EntityError
  */
 class UnprocessableEntityException(
   override val message: String?,
-  private val code: String?,
-  private val errors: List<EntityError>?,
-  private val requestId: String,
+  val code: String?,
+  val errors: List<EntityError>?,
+  val requestId: String,
 ) : Exception(message) {
-  private val status = 422
+  val status = 422
 }

--- a/src/test/kotlin/com/workos/test/mfa/MfaApiTest.kt
+++ b/src/test/kotlin/com/workos/test/mfa/MfaApiTest.kt
@@ -255,7 +255,7 @@ class MfaApiTest : TestBase() {
     stubResponse(
       url = "/auth/challenges/auth_challenge_1234/verify",
       responseBody = """{
-        "code": "Already verified",
+        "code": "already_verifed",
         "message": "Already verified"
       }""",
       responseStatus = 422,
@@ -268,6 +268,13 @@ class MfaApiTest : TestBase() {
 
     assertThrows(UnprocessableEntityException::class.java) {
       workos.mfa.verifyChallenge(options)
+    }
+
+    try {
+      workos.mfa.verifyChallenge(options)
+    } catch (error: UnprocessableEntityException) {
+      assertEquals("already_verifed", error.code)
+      assertEquals("Already verified", error.message)
     }
   }
 }


### PR DESCRIPTION
- Updates the way we are extracting the response body from the HTTP response so that it is agnostic to the response code
- Makes private fields public on our common HTTP exceptions