### PR TITLE
Add Audit Log Export functionality

### DIFF
--- a/src/main/kotlin/com/workos/auditlogs/AuditLogsApi.kt
+++ b/src/main/kotlin/com/workos/auditlogs/AuditLogsApi.kt
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonInclude.Include
 import com.fasterxml.jackson.annotation.JsonProperty
 import com.workos.WorkOS
+import com.workos.auditlogs.models.AuditLogExport
+import com.workos.common.constants.JsonFormatterConstants
 import com.workos.common.http.RequestConfig
 import java.util.Date
 
@@ -39,7 +41,7 @@ class AuditLogsApi(private val workos: WorkOS) {
   class CreateAuditLogEventOptions @JvmOverloads constructor(
     val action: String,
     @JsonProperty("occurred_at")
-    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss.SSSX", timezone = "UTC")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = JsonFormatterConstants.ISO_SIMPLE_DATE_PATTERN, timezone = "UTC")
     val occurredAt: Date,
     val actor: Actor,
     val targets: List<Target>,
@@ -226,5 +228,119 @@ class AuditLogsApi(private val workos: WorkOS) {
     }
 
     workos.post("/audit_logs", configBuilder.build())
+  }
+
+  /**
+   * Parameters for the [createExport] method.
+   */
+  @JsonInclude(Include.NON_NULL)
+  class CreateAuditLogExportOptions @JvmOverloads constructor(
+    @JsonProperty("organization_id")
+    val organizationId: String,
+    @JsonProperty("range_start")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = JsonFormatterConstants.ISO_SIMPLE_DATE_PATTERN, timezone = "UTC")
+    val rangeStart: Date,
+    @JsonProperty("range_end")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = JsonFormatterConstants.ISO_SIMPLE_DATE_PATTERN, timezone = "UTC")
+    val rangeEnd: Date,
+    val actions: List<String>?,
+    val actors: List<String>?,
+    val targets: List<String>?
+  ) {
+    /**
+     * Builder class for [CreateAuditLogExportOptions].
+     */
+    class CreateAuditLogExportOptionsBuilder {
+      private var organizationId: String? = null
+      private var rangeStart: Date? = null
+      private var rangeEnd: Date? = null
+      private var actions: List<String>? = null
+      private var actors: List<String>? = null
+      private var targets: List<String>? = null
+
+      /**
+       * Sets the organizationId.
+       */
+      fun organizationId(value: String) = apply { organizationId = value }
+
+      /**
+       * Sets the start of the export date range.
+       */
+      fun rangeStart(value: Date) = apply { rangeStart = value }
+
+      /**
+       * Sets the end of the export date range.
+       */
+      fun rangeEnd(value: Date) = apply { rangeEnd = value }
+
+      /**
+       * Sets the actions export filter.
+       */
+      fun actions(value: List<String>) = apply { actions = value }
+
+      /**
+       * Sets the actors export filter.
+       */
+      fun actors(value: List<String>) = apply { actors = value }
+
+      /**
+       * Sets the targets export filter.
+       */
+      fun targets(value: List<String>) = apply { targets = value }
+
+      /**
+       * Creates a [EnrollFactorOptions] with the given builder parameters.
+       */
+      fun build(): CreateAuditLogExportOptions {
+        if (organizationId == null) {
+          throw IllegalArgumentException("An organizationId must be provided")
+        }
+
+        if (rangeStart == null) {
+          throw IllegalArgumentException("A rangeStart must be provided")
+        }
+
+        if (rangeEnd == null) {
+          throw IllegalArgumentException("A rangeEnd must be provided")
+        }
+
+        return CreateAuditLogExportOptions(
+          organizationId = organizationId!!,
+          rangeStart = rangeStart!!,
+          rangeEnd = rangeEnd!!,
+          actions = actions,
+          actors = actors,
+          targets = targets,
+        )
+      }
+    }
+
+    /**
+     * @suppress
+     */
+    companion object {
+      @JvmStatic
+      fun builder(): CreateAuditLogExportOptionsBuilder {
+        return CreateAuditLogExportOptionsBuilder()
+      }
+    }
+  }
+
+  /**
+   * Creates an Audit Log Export.
+   */
+  fun createExport(createAuditLogExportOptions: CreateAuditLogExportOptions): AuditLogExport {
+    val config = RequestConfig.builder()
+      .data(createAuditLogExportOptions)
+      .build()
+
+    return workos.post("/audit_logs/exports", AuditLogExport::class.java, config)
+  }
+
+  /**
+   * Returns an Audit Log Export.
+   */
+  fun getExport(auditLogExportId: String): AuditLogExport {
+    return workos.get("/audit_logs/exports/$auditLogExportId", AuditLogExport::class.java)
   }
 }

--- a/src/main/kotlin/com/workos/auditlogs/AuditLogsApi.kt
+++ b/src/main/kotlin/com/workos/auditlogs/AuditLogsApi.kt
@@ -289,7 +289,7 @@ class AuditLogsApi(private val workos: WorkOS) {
       fun targets(value: List<String>) = apply { targets = value }
 
       /**
-       * Creates a [EnrollFactorOptions] with the given builder parameters.
+       * Creates a [CreateAuditLogExportOptions] with the given builder parameters.
        */
       fun build(): CreateAuditLogExportOptions {
         if (organizationId == null) {

--- a/src/main/kotlin/com/workos/auditlogs/AuditLogsApi.kt
+++ b/src/main/kotlin/com/workos/auditlogs/AuditLogsApi.kt
@@ -338,7 +338,7 @@ class AuditLogsApi(private val workos: WorkOS) {
   }
 
   /**
-   * Returns an Audit Log Export.
+   * Retrieves an existing Audit Log Export.
    */
   fun getExport(auditLogExportId: String): AuditLogExport {
     return workos.get("/audit_logs/exports/$auditLogExportId", AuditLogExport::class.java)

--- a/src/main/kotlin/com/workos/auditlogs/models/AuditLogExport.kt
+++ b/src/main/kotlin/com/workos/auditlogs/models/AuditLogExport.kt
@@ -1,0 +1,44 @@
+package com.workos.auditlogs.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonFormat
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.constants.JsonFormatterConstants
+import java.util.Date
+
+/**
+ * Represents a WorkOS AuditLogExport resource. This class is not meant to be
+ * instantiated directly.
+ *
+ * @param obj The unique object identifier type of the record.
+ * @param id The unique identifier for the AuditLogExport.
+ * @param state The state of the AuditLogExport.
+ * @param url The CSV URL of the AuditLogExport.
+ * @param createdAt The timestamp of when the AuditLogExport was created.
+ * @param updatedAt The timestamp of when the AuditLogExport was updated.
+ */
+data class AuditLogExport
+@JsonCreator constructor(
+  @JvmField
+  @JsonProperty("object")
+  val obj: String = "audit_log_export",
+
+  @JvmField
+  val id: String,
+
+  @JvmField
+  val state: AuditLogExportState,
+
+  @JvmField
+  val url: String?,
+
+  @JvmField
+  @JsonProperty("created_at")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = JsonFormatterConstants.ISO_SIMPLE_DATE_PATTERN, timezone = "UTC")
+  val createdAt: Date,
+
+  @JvmField
+  @JsonProperty("updated_at")
+  @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = JsonFormatterConstants.ISO_SIMPLE_DATE_PATTERN, timezone = "UTC")
+  val updatedAt: Date
+)

--- a/src/main/kotlin/com/workos/auditlogs/models/AuditLogExportState.kt
+++ b/src/main/kotlin/com/workos/auditlogs/models/AuditLogExportState.kt
@@ -1,0 +1,23 @@
+package com.workos.auditlogs.models
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * An enumeration of states for a [AuditLogExport]
+ *
+ * @param state The AuditLogExport State string value.
+ */
+enum class AuditLogExportState(@JsonValue val state: String) {
+  /**
+   * The export is still being generated.
+   */
+  Pending("pending"),
+  /**
+   * The export is ready for download.
+   */
+  Ready("ready"),
+  /**
+   * The export has run into an unexpected error.
+   */
+  Error("error"),
+}

--- a/src/main/kotlin/com/workos/common/constants/JsonFormatterConstants.kt
+++ b/src/main/kotlin/com/workos/common/constants/JsonFormatterConstants.kt
@@ -1,0 +1,5 @@
+package com.workos.common.constants
+
+object JsonFormatterConstants {
+  const val ISO_SIMPLE_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSSX"
+}

--- a/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
+++ b/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
@@ -294,7 +294,7 @@ class AuditLogsTest : TestBase() {
         "state": "ready",
         "url": "https://audit-logs.com/download.csv",
         "created_at": "2022-08-17T19:58:50.686Z",
-        "update_at": "2022-08-17T19:58:50.686Z"
+        "updated_at": "2022-08-17T19:58:50.686Z"
       }""",
       requestBody = """{
         "organization_id": "org_123",

--- a/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
+++ b/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
@@ -371,7 +371,7 @@ class AuditLogsTest : TestBase() {
         "id": "audit_log_export_123",
         "state": "pending",
         "created_at": "2022-08-17T19:58:50.686Z",
-        "update_at": "2022-08-17T19:58:50.686Z"
+        "updated_at": "2022-08-17T19:58:50.686Z"
       }""",
     )
 

--- a/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
+++ b/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
@@ -383,5 +383,4 @@ class AuditLogsTest : TestBase() {
     assertEquals(Date(1660766330686), export.createdAt)
     assertEquals(Date(1660766330686), export.updatedAt)
   }
-
 }

--- a/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
+++ b/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
@@ -249,6 +249,7 @@ class AuditLogsTest : TestBase() {
     }
   }
 
+  @Test
   fun createExportShouldNotThrowException() {
     val workos = createWorkOSClient()
 
@@ -283,6 +284,7 @@ class AuditLogsTest : TestBase() {
     assertEquals(Date(1660766330686), export.updatedAt)
   }
 
+  @Test
   fun createExportWithAllOptionShouldNotThrowException() {
     val workos = createWorkOSClient()
 
@@ -325,6 +327,7 @@ class AuditLogsTest : TestBase() {
     assertEquals(Date(1660766330686), export.updatedAt)
   }
 
+  @Test
   fun createExportShouldThrowInvalidDateRangeException() {
     val workos = createWorkOSClient()
 
@@ -361,6 +364,7 @@ class AuditLogsTest : TestBase() {
     }
   }
 
+  @Test
   fun getExportShouldNotThrowException() {
     val workos = createWorkOSClient()
 

--- a/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
+++ b/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
@@ -360,4 +360,28 @@ class AuditLogsTest : TestBase() {
       assertEquals("Start date cannot be before 2022-05-17T00:00:00.000Z", exception.message)
     }
   }
+
+  fun getExportShouldNotThrowException() {
+    val workos = createWorkOSClient()
+
+    stubResponse(
+      url = "/audit_logs/exports/audit_log_export_123",
+      responseBody = """{
+        "object": "audit_log_export",
+        "id": "audit_log_export_123",
+        "state": "pending",
+        "created_at": "2022-08-17T19:58:50.686Z",
+        "update_at": "2022-08-17T19:58:50.686Z"
+      }""",
+    )
+
+    val export = workos.auditLogs.getExport("audit_log_export_123")
+
+    assertEquals("audit_log_export", export.obj)
+    assertEquals("audit_log_export_123", export.id)
+    assertEquals(AuditLogExportState.Pending, export.state)
+    assertEquals(Date(1660766330686), export.createdAt)
+    assertEquals(Date(1660766330686), export.updatedAt)
+  }
+
 }

--- a/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
+++ b/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
@@ -19,6 +19,7 @@ class AuditLogsTest : TestBase() {
         "success": true
       }""",
       requestBody = """{
+<<<<<<< HEAD
         "organization_id": "org_123",
         "event": {
           "occurred_at": "1970-01-15T02:57:07.200Z",
@@ -38,6 +39,24 @@ class AuditLogsTest : TestBase() {
           },
           "version": 1
         }
+=======
+        "occurred_at": "1970-01-15T02:57:07.200Z",
+        "action": "user.signed_in",
+        "actor": {
+          "id": "user_123",
+          "type": "user"
+        },
+        "targets": [
+          {
+            "id": "team_123",
+            "type": "team"
+          }
+        ],
+        "context": {
+          "location": "0.0.0.0"
+        },
+        "version": 1
+>>>>>>> ffa1495 (Format occurred_at as ISO string)
       }"""
     )
 
@@ -61,6 +80,7 @@ class AuditLogsTest : TestBase() {
         "success": true
       }""",
       requestBody = """{
+<<<<<<< HEAD
         "organization_id": "org_123",
         "event": {
           "occurred_at": "1970-01-15T02:57:07.200Z",
@@ -69,6 +89,23 @@ class AuditLogsTest : TestBase() {
             "id": "user_123",
             "type": "user",
             "name": "User",
+=======
+        "occurred_at": "1970-01-15T02:57:07.200Z",
+        "action": "user.signed_in",
+        "actor": {
+          "id": "user_123",
+          "type": "user",
+          "name": "User",
+          "metadata": {
+            "role": "admin"
+          }
+        },
+        "targets": [
+          {
+            "id": "team_123",
+            "type": "team",
+            "name": "Team",
+>>>>>>> ffa1495 (Format occurred_at as ISO string)
             "metadata": {
               "role": "admin"
             }
@@ -203,6 +240,7 @@ class AuditLogsTest : TestBase() {
         }]
       }""",
       requestBody = """{
+<<<<<<< HEAD
         "organization_id": "org_123",
         "event": {
           "occurred_at": "1970-01-15T02:57:07.200Z",
@@ -222,6 +260,24 @@ class AuditLogsTest : TestBase() {
           },
           "version": 1
         }
+=======
+        "occurred_at": "1970-01-15T02:57:07.200Z",
+        "action": "user.signed_in",
+        "actor": {
+          "id": "user_123",
+          "type": "user"
+        },
+        "targets": [
+          {
+            "id": "team_123",
+            "type": "team"
+          }
+        ],
+        "context": {
+          "location": "0.0.0.0"
+        },
+        "version": 1
+>>>>>>> ffa1495 (Format occurred_at as ISO string)
       }""",
       responseStatus = 400
     )

--- a/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
+++ b/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
@@ -1,6 +1,7 @@
 package com.workos.test.auditlogs
 
 import com.workos.auditlogs.AuditLogsApi
+import com.workos.auditlogs.models.AuditLogExportState
 import com.workos.common.exceptions.BadRequestException
 import com.workos.test.TestBase
 import org.junit.jupiter.api.Assertions.assertThrows
@@ -19,7 +20,6 @@ class AuditLogsTest : TestBase() {
         "success": true
       }""",
       requestBody = """{
-<<<<<<< HEAD
         "organization_id": "org_123",
         "event": {
           "occurred_at": "1970-01-15T02:57:07.200Z",
@@ -39,24 +39,6 @@ class AuditLogsTest : TestBase() {
           },
           "version": 1
         }
-=======
-        "occurred_at": "1970-01-15T02:57:07.200Z",
-        "action": "user.signed_in",
-        "actor": {
-          "id": "user_123",
-          "type": "user"
-        },
-        "targets": [
-          {
-            "id": "team_123",
-            "type": "team"
-          }
-        ],
-        "context": {
-          "location": "0.0.0.0"
-        },
-        "version": 1
->>>>>>> ffa1495 (Format occurred_at as ISO string)
       }"""
     )
 
@@ -80,7 +62,6 @@ class AuditLogsTest : TestBase() {
         "success": true
       }""",
       requestBody = """{
-<<<<<<< HEAD
         "organization_id": "org_123",
         "event": {
           "occurred_at": "1970-01-15T02:57:07.200Z",
@@ -89,23 +70,6 @@ class AuditLogsTest : TestBase() {
             "id": "user_123",
             "type": "user",
             "name": "User",
-=======
-        "occurred_at": "1970-01-15T02:57:07.200Z",
-        "action": "user.signed_in",
-        "actor": {
-          "id": "user_123",
-          "type": "user",
-          "name": "User",
-          "metadata": {
-            "role": "admin"
-          }
-        },
-        "targets": [
-          {
-            "id": "team_123",
-            "type": "team",
-            "name": "Team",
->>>>>>> ffa1495 (Format occurred_at as ISO string)
             "metadata": {
               "role": "admin"
             }
@@ -240,7 +204,6 @@ class AuditLogsTest : TestBase() {
         }]
       }""",
       requestBody = """{
-<<<<<<< HEAD
         "organization_id": "org_123",
         "event": {
           "occurred_at": "1970-01-15T02:57:07.200Z",
@@ -260,24 +223,6 @@ class AuditLogsTest : TestBase() {
           },
           "version": 1
         }
-=======
-        "occurred_at": "1970-01-15T02:57:07.200Z",
-        "action": "user.signed_in",
-        "actor": {
-          "id": "user_123",
-          "type": "user"
-        },
-        "targets": [
-          {
-            "id": "team_123",
-            "type": "team"
-          }
-        ],
-        "context": {
-          "location": "0.0.0.0"
-        },
-        "version": 1
->>>>>>> ffa1495 (Format occurred_at as ISO string)
       }""",
       responseStatus = 400
     )
@@ -301,6 +246,118 @@ class AuditLogsTest : TestBase() {
       assertEquals("invalid_audit_log", exception.code)
       assertEquals("Invalid Audit Log event", exception.message)
       assert(exception.errors?.size == 1)
+    }
+  }
+
+  fun createExportShouldNotThrowException() {
+    val workos = createWorkOSClient()
+
+    stubResponse(
+      url = "/audit_logs/exports",
+      responseBody = """{
+        "object": "audit_log_export",
+        "id": "audit_log_export_123",
+        "state": "pending",
+        "created_at": "2022-08-17T19:58:50.686Z",
+        "update_at": "2022-08-17T19:58:50.686Z"
+      }""",
+      requestBody = """{
+        "organization_id": "org_123",
+        "range_start": "2022-07-17T19:58:50.686Z",
+        "range_end": "2022-09-17T19:58:50.686Z"
+      }"""
+    )
+
+    val options = AuditLogsApi.CreateAuditLogExportOptions.builder()
+      .organizationId("org_123")
+      .rangeStart(Date(1658087930686))
+      .rangeEnd(Date(1663444730686))
+      .build()
+
+    val export = workos.auditLogs.createExport(options)
+
+    assertEquals("audit_log_export", export.obj)
+    assertEquals("audit_log_export_123", export.id)
+    assertEquals(AuditLogExportState.Pending, export.state)
+    assertEquals(Date(1660766330686), export.createdAt)
+    assertEquals(Date(1660766330686), export.updatedAt)
+  }
+
+  fun createExportWithAllOptionShouldNotThrowException() {
+    val workos = createWorkOSClient()
+
+    stubResponse(
+      url = "/audit_logs/exports",
+      responseBody = """{
+        "object": "audit_log_export",
+        "id": "audit_log_export_123",
+        "state": "ready",
+        "url": "https://audit-logs.com/download.csv",
+        "created_at": "2022-08-17T19:58:50.686Z",
+        "update_at": "2022-08-17T19:58:50.686Z"
+      }""",
+      requestBody = """{
+        "organization_id": "org_123",
+        "range_start": "2022-07-17T19:58:50.686Z",
+        "range_end": "2022-09-17T19:58:50.686Z",
+        "actions": ["foo", "bar"],
+        "actors": ["foo", "bar"],
+        "targets": ["foo", "bar"]
+      }"""
+    )
+
+    val options = AuditLogsApi.CreateAuditLogExportOptions.builder()
+      .organizationId("org_123")
+      .rangeStart(Date(1658087930686))
+      .rangeEnd(Date(1663444730686))
+      .actions(listOf("foo", "bar"))
+      .actors(listOf("foo", "bar"))
+      .targets(listOf("foo", "bar"))
+      .build()
+
+    val export = workos.auditLogs.createExport(options)
+
+    assertEquals("audit_log_export", export.obj)
+    assertEquals("audit_log_export_123", export.id)
+    assertEquals(AuditLogExportState.Ready, export.state)
+    assertEquals("https://audit-logs.com/download.csv", export.url)
+    assertEquals(Date(1660766330686), export.createdAt)
+    assertEquals(Date(1660766330686), export.updatedAt)
+  }
+
+  fun createExportShouldThrowInvalidDateRangeException() {
+    val workos = createWorkOSClient()
+
+    stubResponse(
+      url = "/audit_logs/exports",
+      responseBody = """{
+        "code": "invalid_date_range_exception",
+        "message": "Start date cannot be before 2022-05-17T00:00:00.000Z"
+      }""",
+      requestBody = """{
+        "organization_id": "org_123",
+        "range_start": "2022-07-17T19:58:50.686Z",
+        "range_end": "2022-09-17T19:58:50.686Z"
+      }""",
+      responseStatus = 400
+    )
+
+    val options = AuditLogsApi.CreateAuditLogExportOptions.builder()
+      .organizationId("org_123")
+      .rangeStart(Date(1658087930686))
+      .rangeEnd(Date(1663444730686))
+      .build()
+
+    assertThrows(BadRequestException::class.java) {
+      workos.auditLogs.createExport(options)
+    }
+
+    try {
+      workos.auditLogs.createExport(options)
+    } catch (exception: BadRequestException) {
+      assertEquals(400, exception.status)
+      assertEquals("invalid_date_range_exception", exception.code)
+      assertEquals("Start date cannot be before 2022-05-17T00:00:00.000Z", exception.message)
     }
   }
 }

--- a/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
+++ b/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
@@ -259,7 +259,7 @@ class AuditLogsTest : TestBase() {
         "id": "audit_log_export_123",
         "state": "pending",
         "created_at": "2022-08-17T19:58:50.686Z",
-        "update_at": "2022-08-17T19:58:50.686Z"
+        "updated_at": "2022-08-17T19:58:50.686Z"
       }""",
       requestBody = """{
         "organization_id": "org_123",


### PR DESCRIPTION
Note: this branch is currently based off https://github.com/workos/workos-kotlin/pull/127 and should be reviewed second.

- Adds `createExport` to `AuditLogsApi` module
- Adds `getExport` to `AuditLogsApi` module