### PR TITLE
Bump version to 2.6.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import java.io.FileOutputStream
 import java.util.Properties
 
 group = "com.workos"
-version = "2.6.0"
+version = "2.6.1"
 
 if (!project.hasProperty("release")) {
   version = "$version-SNAPSHOT"


### PR DESCRIPTION
Bump minor verison to 2.6.1:

FIX: 
Make totp properties nullable https://github.com/workos/workos-kotlin/pull/147