### PR TITLE
Add groups attribute to user profile

### DIFF
--- a/src/main/kotlin/com/workos/sso/models/Profile.kt
+++ b/src/main/kotlin/com/workos/sso/models/Profile.kt
@@ -16,6 +16,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param email The user's email address.
  * @param firstName The user's first name.
  * @param lastName The user's last name.
+ * @param groups The user's group memberships.
  * @param rawAttributes Object of key-value pairs containing relevant user data from the Identity Provider.
  */
 data class Profile
@@ -53,6 +54,10 @@ data class Profile
   @JvmField
   @JsonProperty("last_name")
   val lastName: String?,
+
+  @JvmField
+  @JsonProperty("groups")
+  val groups: List<String>?,
 
   @JvmField
   @JsonProperty("raw_attributes")

--- a/src/test/kotlin/com/workos/test/sso/SsoApiTest.kt
+++ b/src/test/kotlin/com/workos/test/sso/SsoApiTest.kt
@@ -185,6 +185,42 @@ class SsoApiTest : TestBase() {
   }
 
   @Test
+  fun getProfileAndTokenWithGroupsShouldReturnGroups() {
+    val workos = createWorkOSClient()
+
+    stubResponse(
+      url = "/sso/token",
+      requestBody = """{
+        "client_id": "clientId",
+        "client_secret": "apiKey",
+        "code": "code",
+        "grant_type": "authorization_code"
+      }""",
+      responseBody = """{
+        "access_token": "01DMEK0J53CVMC32CK5SE0KZ8Q",
+        "profile": {
+          "connection_id": "conn_01E4ZCR3C56J083X43JQXF3JK5",
+          "connection_type": "OktaSAML",
+          "email": "todd@foo-corp.com",
+          "first_name": "Todd",
+          "id": "prof_01DMC79VCBZ0NY2099737PSVF1",
+          "idp_id": "00u1a0ufowBJlzPlk357",
+          "last_name": "Rundgren",
+          "groups":["Admins", "Developers"],
+          "object": "profile",
+          "organization_id": "org_01FJYCNTB6VC4K5R8BTF86286Q",
+          "raw_attributes": {"foo": "bar", "groups":["Admins", "Developers"]}
+        }
+      }"""
+    )
+
+    val profileAndToken = workos.sso.getProfileAndToken("code", "clientId")
+    val profile = profileAndToken.profile
+
+    assertEquals(["Admins", "Developers"], profile.groups)
+  }
+
+  @Test
   fun getProfileShouldReturnPayload() {
     val workos = createWorkOSClient()
 

--- a/src/test/kotlin/com/workos/test/sso/SsoApiTest.kt
+++ b/src/test/kotlin/com/workos/test/sso/SsoApiTest.kt
@@ -9,6 +9,7 @@ import com.workos.test.TestBase
 import org.junit.jupiter.api.Assertions.assertThrows
 import kotlin.test.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 
 class SsoApiTest : TestBase() {
   class ExampleResponseType {
@@ -218,6 +219,41 @@ class SsoApiTest : TestBase() {
     val profile = profileAndToken.profile
 
     assertEquals(listOf("Admins", "Developers"), profile.groups)
+  }
+
+  @Test
+  fun getProfileAndTokenWithoutGroupsShouldNotReturnGroups() {
+    val workos = createWorkOSClient()
+
+    stubResponse(
+      url = "/sso/token",
+      requestBody = """{
+        "client_id": "clientId",
+        "client_secret": "apiKey",
+        "code": "code",
+        "grant_type": "authorization_code"
+      }""",
+      responseBody = """{
+        "access_token": "01DMEK0J53CVMC32CK5SE0KZ8Q",
+        "profile": {
+          "connection_id": "conn_01E4ZCR3C56J083X43JQXF3JK5",
+          "connection_type": "OktaSAML",
+          "email": "todd@foo-corp.com",
+          "first_name": "Todd",
+          "id": "prof_01DMC79VCBZ0NY2099737PSVF1",
+          "idp_id": "00u1a0ufowBJlzPlk357",
+          "last_name": "Rundgren",
+          "object": "profile",
+          "organization_id": "org_01FJYCNTB6VC4K5R8BTF86286Q",
+          "raw_attributes": {"foo": "bar"}
+        }
+      }"""
+    )
+
+    val profileAndToken = workos.sso.getProfileAndToken("code", "clientId")
+    val profile = profileAndToken.profile
+
+    assertNull(profile.groups)
   }
 
   @Test

--- a/src/test/kotlin/com/workos/test/sso/SsoApiTest.kt
+++ b/src/test/kotlin/com/workos/test/sso/SsoApiTest.kt
@@ -217,7 +217,7 @@ class SsoApiTest : TestBase() {
     val profileAndToken = workos.sso.getProfileAndToken("code", "clientId")
     val profile = profileAndToken.profile
 
-    assertEquals(["Admins", "Developers"], profile.groups)
+    assertEquals(listOf("Admins", "Developers"), profile.groups)
   }
 
   @Test


### PR DESCRIPTION
## Description

Adds groups attribute to user profile. Available behind a feature flag.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
