### PR TITLE
Add `created_at` field to webhook classes

### DIFF
--- a/src/main/kotlin/com/workos/webhooks/models/ConnectionActivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/ConnectionActivatedEvent.kt
@@ -15,5 +15,8 @@ class ConnectionActivatedEvent
   override val event: EventType,
 
   @JvmField
-  override val data: Connection
+  override val data: Connection,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/ConnectionActivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/ConnectionActivatedEvent.kt
@@ -18,5 +18,5 @@ class ConnectionActivatedEvent
   override val data: Connection,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/ConnectionDeactivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/ConnectionDeactivatedEvent.kt
@@ -15,5 +15,8 @@ class ConnectionDeactivatedEvent
   override val event: EventType,
 
   @JvmField
-  override val data: Connection
+  override val data: Connection,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/ConnectionDeactivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/ConnectionDeactivatedEvent.kt
@@ -18,5 +18,5 @@ class ConnectionDeactivatedEvent
   override val data: Connection,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/ConnectionDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/ConnectionDeletedEvent.kt
@@ -14,5 +14,8 @@ class ConnectionDeletedEvent @JsonCreator constructor(
   override val event: EventType,
 
   @JvmField
-  override val data: Connection
+  override val data: Connection,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/ConnectionDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/ConnectionDeletedEvent.kt
@@ -17,5 +17,5 @@ class ConnectionDeletedEvent @JsonCreator constructor(
   override val data: Connection,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryActivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryActivatedEvent.kt
@@ -17,5 +17,5 @@ class DirectoryActivatedEvent @JsonCreator constructor(
   override val data: Directory,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryActivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryActivatedEvent.kt
@@ -14,5 +14,8 @@ class DirectoryActivatedEvent @JsonCreator constructor(
   override val event: EventType,
 
   @JvmField
-  override val data: Directory
+  override val data: Directory,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryDeactivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryDeactivatedEvent.kt
@@ -14,5 +14,8 @@ class DirectoryDeactivatedEvent @JsonCreator constructor(
   override val event: EventType,
 
   @JvmField
-  override val data: Directory
+  override val data: Directory,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryDeactivatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryDeactivatedEvent.kt
@@ -17,5 +17,5 @@ class DirectoryDeactivatedEvent @JsonCreator constructor(
   override val data: Directory,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryDeletedEvent.kt
@@ -17,5 +17,5 @@ class DirectoryDeletedEvent @JsonCreator constructor(
   override val data: Directory,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryDeletedEvent.kt
@@ -14,5 +14,8 @@ class DirectoryDeletedEvent @JsonCreator constructor(
   override val event: EventType,
 
   @JvmField
-  override val data: Directory
+  override val data: Directory,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupCreatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupCreatedEvent.kt
@@ -13,5 +13,8 @@ class DirectoryGroupCreatedEvent(
   override val event: EventType,
 
   @JvmField
-  override val data: Group
+  override val data: Group,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupCreatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupCreatedEvent.kt
@@ -16,5 +16,5 @@ class DirectoryGroupCreatedEvent(
   override val data: Group,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupDeletedEvent.kt
@@ -17,5 +17,5 @@ class DirectoryGroupDeletedEvent @JsonCreator constructor(
   override val data: Group,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupDeletedEvent.kt
@@ -14,5 +14,8 @@ class DirectoryGroupDeletedEvent @JsonCreator constructor(
   override val event: EventType,
 
   @JvmField
-  override val data: Group
+  override val data: Group,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUpdatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUpdatedEvent.kt
@@ -17,5 +17,5 @@ class DirectoryGroupUpdatedEvent
   override val data: GroupUpdated,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUpdatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUpdatedEvent.kt
@@ -14,5 +14,8 @@ class DirectoryGroupUpdatedEvent
   override val event: EventType,
 
   @JvmField
-  override val data: GroupUpdated
+  override val data: GroupUpdated,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserAddedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserAddedEvent.kt
@@ -13,5 +13,8 @@ class DirectoryGroupUserAddedEvent @JsonCreator constructor(
   override val event: EventType,
 
   @JvmField
-  override val data: DirectoryGroupUserEvent
+  override val data: DirectoryGroupUserEvent,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserAddedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserAddedEvent.kt
@@ -16,5 +16,5 @@ class DirectoryGroupUserAddedEvent @JsonCreator constructor(
   override val data: DirectoryGroupUserEvent,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserRemovedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserRemovedEvent.kt
@@ -14,5 +14,5 @@ class DirectoryGroupUserRemovedEvent(
   override val data: DirectoryGroupUserEvent,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserRemovedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryGroupUserRemovedEvent.kt
@@ -11,5 +11,8 @@ class DirectoryGroupUserRemovedEvent(
   override val event: EventType,
 
   @JvmField
-  override val data: DirectoryGroupUserEvent
+  override val data: DirectoryGroupUserEvent,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryUserCreatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryUserCreatedEvent.kt
@@ -13,5 +13,8 @@ class DirectoryUserCreatedEvent(
   override val event: EventType,
 
   @JvmField
-  override val data: User
+  override val data: User,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryUserCreatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryUserCreatedEvent.kt
@@ -16,5 +16,5 @@ class DirectoryUserCreatedEvent(
   override val data: User,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryUserDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryUserDeletedEvent.kt
@@ -13,5 +13,8 @@ class DirectoryUserDeletedEvent(
   override val event: EventType,
 
   @JvmField
-  override val data: User
+  override val data: User,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryUserDeletedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryUserDeletedEvent.kt
@@ -16,5 +16,5 @@ class DirectoryUserDeletedEvent(
   override val data: User,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryUserUpdatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryUserUpdatedEvent.kt
@@ -14,5 +14,5 @@ class DirectoryUserUpdatedEvent(
   override val data: UserUpdated,
 
   @JvmField
-  override val created_at: String
-) : WebhookEvent(id, event, data)
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/DirectoryUserUpdatedEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/DirectoryUserUpdatedEvent.kt
@@ -11,5 +11,8 @@ class DirectoryUserUpdatedEvent(
   override val event: EventType,
 
   @JvmField
-  override val data: UserUpdated
+  override val data: UserUpdated,
+
+  @JvmField
+  override val created_at: String
 ) : WebhookEvent(id, event, data)

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookEvent.kt
@@ -24,5 +24,5 @@ abstract class WebhookEvent
   open val data: Any,
 
   @JvmField
-  override val createdAt: String
+  open val createdAt: String
 )

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookEvent.kt
@@ -24,5 +24,5 @@ abstract class WebhookEvent
   open val data: Any,
 
   @JvmField
-  override val created_at: String
+  override val createdAt: String
 )

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookEvent.kt
@@ -21,5 +21,8 @@ abstract class WebhookEvent
   open val event: EventType,
 
   @JvmField
-  open val data: Any
+  open val data: Any,
+
+  @JvmField
+  override val created_at: String
 )

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -30,22 +30,23 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
     val id = mapper.readValue(rootNode?.get("id")?.traverse(), String::class.java)
     val eventType = mapper.readValue(rootNode?.get("event")?.traverse(), EventType::class.java)!!
     val data = rootNode?.get("data")
+    val created_at = mapper.readValue(rootNode?.get("created_at")?.traverse(), String::class.java)
 
     return when (eventType) {
-      EventType.ConnectionActivated -> ConnectionActivatedEvent(id, eventType, deserializeData(data, Connection::class.java))
-      EventType.ConnectionDeactivated -> ConnectionDeactivatedEvent(id, eventType, deserializeData(data, Connection::class.java))
-      EventType.ConnectionDeleted -> ConnectionDeletedEvent(id, eventType, deserializeData(data, Connection::class.java))
-      EventType.DirectoryActivated -> DirectoryActivatedEvent(id, eventType, deserializeData(data, Directory::class.java))
-      EventType.DirectoryDeactivated -> DirectoryDeactivatedEvent(id, eventType, deserializeData(data, Directory::class.java))
-      EventType.DirectoryDeleted -> DirectoryDeletedEvent(id, eventType, deserializeData(data, Directory::class.java))
-      EventType.DirectoryUserCreated -> DirectoryUserCreatedEvent(id, eventType, deserializeData(data, User::class.java))
-      EventType.DirectoryUserUpdated -> DirectoryUserUpdatedEvent(id, eventType, deserializeData(data, UserUpdated::class.java))
-      EventType.DirectoryUserDeleted -> DirectoryUserDeletedEvent(id, eventType, deserializeData(data, User::class.java))
-      EventType.DirectoryGroupCreated -> DirectoryGroupCreatedEvent(id, eventType, deserializeData(data, Group::class.java))
-      EventType.DirectoryGroupUpdated -> DirectoryGroupUpdatedEvent(id, eventType, deserializeData(data, GroupUpdated::class.java))
-      EventType.DirectoryGroupDeleted -> DirectoryGroupDeletedEvent(id, eventType, deserializeData(data, Group::class.java))
-      EventType.DirectoryGroupUserAdded -> DirectoryGroupUserAddedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java))
-      EventType.DirectoryGroupUserRemoved -> DirectoryGroupUserRemovedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java))
+      EventType.ConnectionActivated -> ConnectionActivatedEvent(id, eventType, deserializeData(data, Connection::class.java), created_at)
+      EventType.ConnectionDeactivated -> ConnectionDeactivatedEvent(id, eventType, deserializeData(data, Connection::class.java), created_at)
+      EventType.ConnectionDeleted -> ConnectionDeletedEvent(id, eventType, deserializeData(data, Connection::class.java), created_at)
+      EventType.DirectoryActivated -> DirectoryActivatedEvent(id, eventType, deserializeData(data, Directory::class.java), created_at)
+      EventType.DirectoryDeactivated -> DirectoryDeactivatedEvent(id, eventType, deserializeData(data, Directory::class.java), created_at)
+      EventType.DirectoryDeleted -> DirectoryDeletedEvent(id, eventType, deserializeData(data, Directory::class.java), created_at)
+      EventType.DirectoryUserCreated -> DirectoryUserCreatedEvent(id, eventType, deserializeData(data, User::class.java), created_at)
+      EventType.DirectoryUserUpdated -> DirectoryUserUpdatedEvent(id, eventType, deserializeData(data, UserUpdated::class.java), created_at)
+      EventType.DirectoryUserDeleted -> DirectoryUserDeletedEvent(id, eventType, deserializeData(data, User::class.java), created_at)
+      EventType.DirectoryGroupCreated -> DirectoryGroupCreatedEvent(id, eventType, deserializeData(data, Group::class.java), created_at)
+      EventType.DirectoryGroupUpdated -> DirectoryGroupUpdatedEvent(id, eventType, deserializeData(data, GroupUpdated::class.java), created_at)
+      EventType.DirectoryGroupDeleted -> DirectoryGroupDeletedEvent(id, eventType, deserializeData(data, Group::class.java), created_at)
+      EventType.DirectoryGroupUserAdded -> DirectoryGroupUserAddedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), created_at)
+      EventType.DirectoryGroupUserRemoved -> DirectoryGroupUserRemovedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), created_at)
     }
   }
 

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -30,23 +30,23 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
     val id = mapper.readValue(rootNode?.get("id")?.traverse(), String::class.java)
     val eventType = mapper.readValue(rootNode?.get("event")?.traverse(), EventType::class.java)!!
     val data = rootNode?.get("data")
-    val created_at = mapper.readValue(rootNode?.get("created_at")?.traverse(), String::class.java)
+    val createdAt = mapper.readValue(rootNode?.get("created_at")?.traverse(), String::class.java)
 
     return when (eventType) {
-      EventType.ConnectionActivated -> ConnectionActivatedEvent(id, eventType, deserializeData(data, Connection::class.java), created_at)
-      EventType.ConnectionDeactivated -> ConnectionDeactivatedEvent(id, eventType, deserializeData(data, Connection::class.java), created_at)
-      EventType.ConnectionDeleted -> ConnectionDeletedEvent(id, eventType, deserializeData(data, Connection::class.java), created_at)
-      EventType.DirectoryActivated -> DirectoryActivatedEvent(id, eventType, deserializeData(data, Directory::class.java), created_at)
-      EventType.DirectoryDeactivated -> DirectoryDeactivatedEvent(id, eventType, deserializeData(data, Directory::class.java), created_at)
-      EventType.DirectoryDeleted -> DirectoryDeletedEvent(id, eventType, deserializeData(data, Directory::class.java), created_at)
-      EventType.DirectoryUserCreated -> DirectoryUserCreatedEvent(id, eventType, deserializeData(data, User::class.java), created_at)
-      EventType.DirectoryUserUpdated -> DirectoryUserUpdatedEvent(id, eventType, deserializeData(data, UserUpdated::class.java), created_at)
-      EventType.DirectoryUserDeleted -> DirectoryUserDeletedEvent(id, eventType, deserializeData(data, User::class.java), created_at)
-      EventType.DirectoryGroupCreated -> DirectoryGroupCreatedEvent(id, eventType, deserializeData(data, Group::class.java), created_at)
-      EventType.DirectoryGroupUpdated -> DirectoryGroupUpdatedEvent(id, eventType, deserializeData(data, GroupUpdated::class.java), created_at)
-      EventType.DirectoryGroupDeleted -> DirectoryGroupDeletedEvent(id, eventType, deserializeData(data, Group::class.java), created_at)
-      EventType.DirectoryGroupUserAdded -> DirectoryGroupUserAddedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), created_at)
-      EventType.DirectoryGroupUserRemoved -> DirectoryGroupUserRemovedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), created_at)
+      EventType.ConnectionActivated -> ConnectionActivatedEvent(id, eventType, deserializeData(data, Connection::class.java), createdAt)
+      EventType.ConnectionDeactivated -> ConnectionDeactivatedEvent(id, eventType, deserializeData(data, Connection::class.java), createdAt)
+      EventType.ConnectionDeleted -> ConnectionDeletedEvent(id, eventType, deserializeData(data, Connection::class.java), createdAt)
+      EventType.DirectoryActivated -> DirectoryActivatedEvent(id, eventType, deserializeData(data, Directory::class.java), createdAt)
+      EventType.DirectoryDeactivated -> DirectoryDeactivatedEvent(id, eventType, deserializeData(data, Directory::class.java), createdAt)
+      EventType.DirectoryDeleted -> DirectoryDeletedEvent(id, eventType, deserializeData(data, Directory::class.java), createdAt)
+      EventType.DirectoryUserCreated -> DirectoryUserCreatedEvent(id, eventType, deserializeData(data, User::class.java), createdAt)
+      EventType.DirectoryUserUpdated -> DirectoryUserUpdatedEvent(id, eventType, deserializeData(data, UserUpdated::class.java), createdAt)
+      EventType.DirectoryUserDeleted -> DirectoryUserDeletedEvent(id, eventType, deserializeData(data, User::class.java), createdAt)
+      EventType.DirectoryGroupCreated -> DirectoryGroupCreatedEvent(id, eventType, deserializeData(data, Group::class.java), createdAt)
+      EventType.DirectoryGroupUpdated -> DirectoryGroupUpdatedEvent(id, eventType, deserializeData(data, GroupUpdated::class.java), createdAt)
+      EventType.DirectoryGroupDeleted -> DirectoryGroupDeletedEvent(id, eventType, deserializeData(data, Group::class.java), createdAt)
+      EventType.DirectoryGroupUserAdded -> DirectoryGroupUserAddedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), createdAt)
+      EventType.DirectoryGroupUserRemoved -> DirectoryGroupUserRemovedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), createdAt)
     }
   }
 

--- a/src/test/kotlin/com/workos/test/webhooks/ConnectionWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/ConnectionWebhookTests.kt
@@ -26,7 +26,8 @@ class ConnectionWebhookTests : TestBase() {
         "connection_type": "GoogleSAML",
         "organization_id": "org_01FKPWZWPHE9VN2QXJ7G1BZYP8"
       },
-      "event": "${eventType.value}"
+      "event": "${eventType.value}",
+      "created_at": "2021-11-20T10:15:23.713Z"
     }
     """
   }

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryGroupWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryGroupWebhookTests.kt
@@ -131,7 +131,7 @@ class DirectoryGroupWebhookTests : TestBase() {
         "directory_id": "$directoryId"
       },
       "event": "${eventType.value}",
-      "created_at": "2021-06-25T19:07:33.155Z",
+      "created_at": "2021-06-25T19:07:33.155Z"
     }
     """
   }
@@ -170,7 +170,7 @@ class DirectoryGroupWebhookTests : TestBase() {
         }
       },
       "event": "${eventType.value}",
-      "created_at": "2021-06-25T19:07:33.155Z",
+      "created_at": "2021-06-25T19:07:33.155Z"
     }
     """
   }

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryGroupWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryGroupWebhookTests.kt
@@ -39,7 +39,8 @@ class DirectoryGroupWebhookTests : TestBase() {
           ]
         }
       },
-      "event": "${eventType.value}"
+      "event": "${eventType.value}",
+      "created_at": "2021-06-25T19:07:33.155Z"
     }
     """
   }
@@ -129,7 +130,8 @@ class DirectoryGroupWebhookTests : TestBase() {
         },
         "directory_id": "$directoryId"
       },
-      "event": "${eventType.value}"
+      "event": "${eventType.value}",
+      "created_at": "2021-06-25T19:07:33.155Z",
     }
     """
   }
@@ -167,7 +169,8 @@ class DirectoryGroupWebhookTests : TestBase() {
           }
         }
       },
-      "event": "${eventType.value}"
+      "event": "${eventType.value}",
+      "created_at": "2021-06-25T19:07:33.155Z",
     }
     """
   }

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryUserWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryUserWebhookTests.kt
@@ -158,7 +158,7 @@ class DirectoryUserWebhookTests : TestBase() {
         }
       },
       "event": "${eventType.value}",
-      "created_at": "2021-06-25T19:07:33.155Z",
+      "created_at": "2021-06-25T19:07:33.155Z"
     }"""
   }
 

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryUserWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryUserWebhookTests.kt
@@ -75,7 +75,8 @@ class DirectoryUserWebhookTests : TestBase() {
         },
         "custom_attributes": {}
       },
-      "event": "${eventType.value}"
+      "event": "${eventType.value}",
+      "created_at": "2021-06-25T19:07:33.155Z"
     }"""
   }
 
@@ -156,7 +157,8 @@ class DirectoryUserWebhookTests : TestBase() {
           }
         }
       },
-      "event": "${eventType.value}"
+      "event": "${eventType.value}",
+      "created_at": "2021-06-25T19:07:33.155Z",
     }"""
   }
 

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryWebhookTests.kt
@@ -26,7 +26,8 @@ class DirectoryWebhookTests : TestBase() {
         "updated_at": "2021-11-20T10:16:26.921Z",
         "organization_id": "org_01FKPWZWPHE9VN2QXJ7G1BZYP8"
       },
-      "event": "${eventType.value}"
+      "event": "${eventType.value}",
+      "created_at": "2021-11-20T10:15:50.695Z"
     }
     """
   }

--- a/src/test/kotlin/com/workos/test/webhooks/WebhooksApiTest.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/WebhooksApiTest.kt
@@ -75,7 +75,8 @@ class WebhooksApiTest : TestBase() {
           }
         }
       },
-      "event": "$eventType"
+      "event": "$eventType",
+      "created_at": "2021-06-25T19:07:33.155Z"
     }"""
 
   private val testWebhookWithUnknownProperties = """
@@ -99,7 +100,8 @@ class WebhooksApiTest : TestBase() {
         "new_unknown_property": {},
         "another_unknown_property": "foo bar"
       },
-      "event": "$eventType"
+      "event": "$eventType",
+      "created_at": "2021-06-25T19:07:33.155Z"
     }"""
 
   companion object {


### PR DESCRIPTION
## Description
We've recently added a new `created_at` field to webhook request payload, 
This PR updates the SDK where needed

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
