### PR TITLE
Update `DirectoryType` enum members

### DIFF
--- a/src/main/kotlin/com/workos/directorysync/models/DirectoryType.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/DirectoryType.kt
@@ -19,7 +19,7 @@ enum class DirectoryType(@JsonValue val type: String) {
   /**
    * Breathe HR
    */
-  BreatheHr("breathehr"),
+  BreatheHr("breathe hr"),
   /**
    * Cezanne HR
    */
@@ -27,7 +27,7 @@ enum class DirectoryType(@JsonValue val type: String) {
   /**
    * Cyberark SCIM 2.0
    */
-  CyberarkSCIMV2_0("cyberark scim v2.0\""),
+  CyberarkSCIMV2_0("cyberark scim v2.0"),
   /**
    * FourthHR
    */
@@ -44,10 +44,6 @@ enum class DirectoryType(@JsonValue val type: String) {
    * Google Workspace https://workspace.google.com/
    */
   GSuiteDirectory("gsuite directory"),
-  /**
-   * Gusto https://gusto.com/
-   */
-  Gusto("gusto"),
   /**
    * Hibob https://www.hibob.com/
    */
@@ -73,13 +69,17 @@ enum class DirectoryType(@JsonValue val type: String) {
    */
   PeopleHR("people hr"),
   /**
+   * Persionio  https://www.personio.com/
+   */
+  Personio("personio"),
+  /**
    * PingFederate SCIM 2.0  https://pingfederate.com/
    */
   PingFederateSCIMV2_0("pingfederate scim v2.0"),
   /**
    * Rippling https://www.rippling.com/
    */
-  Rippling("rippling"),
+  Rippling("rippling scim v2.0"),
   /**
    * Workday https://www.workday.com/
    */


### PR DESCRIPTION
## Description

This PR updates the `DirectoryType` enum members for parity/accuracy with the supported directory types.

Resolves #162.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
