### PR TITLE
Account for unknown `DirectoryType` values

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -9,6 +9,7 @@ agent:
 
 blocks:
   - name: Gradle build
+    dependencies: []
     task:
       jobs:
         - name: Build
@@ -17,6 +18,7 @@ blocks:
             - ./gradlew build
 
   - name: Gradle test
+    dependencies: []
     task:
       jobs:
         - name: Test

--- a/src/main/kotlin/com/workos/WorkOS.kt
+++ b/src/main/kotlin/com/workos/WorkOS.kt
@@ -127,7 +127,9 @@ class WorkOS(
 
   private val manager = FuelManager()
 
-  private val mapper = jacksonObjectMapper()
+  private val mapper = jacksonMapperBuilder()
+    .enable(READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+    .build()
 
   init {
     if (apiKey.isNullOrBlank()) {

--- a/src/main/kotlin/com/workos/WorkOS.kt
+++ b/src/main/kotlin/com/workos/WorkOS.kt
@@ -1,7 +1,7 @@
 package com.workos
 
 import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.github.kittinunf.fuel.core.FuelManager
 import com.github.kittinunf.fuel.core.Request
 import com.github.kittinunf.fuel.core.Response
@@ -128,7 +128,7 @@ class WorkOS(
   private val manager = FuelManager()
 
   private val mapper = jacksonMapperBuilder()
-    .enable(READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+    .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
     .build()
 
   init {

--- a/src/main/kotlin/com/workos/directorysync/models/DirectoryType.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/DirectoryType.kt
@@ -1,5 +1,6 @@
 package com.workos.directorysync.models
 
+import com.fasterxml.jackson.annotation.JsonEnumDefaultValue
 import com.fasterxml.jackson.annotation.JsonValue
 
 /**
@@ -88,5 +89,5 @@ enum class DirectoryType(@JsonValue val type: String) {
    * An unknown directory type.
    */
   @JsonEnumDefaultValue
-  Unknown
+  Unknown("unknown")
 }

--- a/src/main/kotlin/com/workos/directorysync/models/DirectoryType.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/DirectoryType.kt
@@ -84,4 +84,9 @@ enum class DirectoryType(@JsonValue val type: String) {
    * Workday https://www.workday.com/
    */
   Workday("workday"),
+  /**
+   * An unknown directory type.
+   */
+  @JsonEnumDefaultValue
+  Unknown
 }

--- a/src/main/kotlin/com/workos/webhooks/WebhooksApi.kt
+++ b/src/main/kotlin/com/workos/webhooks/WebhooksApi.kt
@@ -1,5 +1,6 @@
 package com.workos.webhooks
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.workos.webhooks.models.WebhookEvent
 import org.apache.commons.codec.binary.Hex
 import java.security.MessageDigest
@@ -14,7 +15,9 @@ import kotlin.jvm.Throws
  * with WorkOS Webhooks.
  */
 class WebhooksApi() {
-  private val objectMapper = jacksonObjectMapper()
+  private val objectMapper = jacksonMapperBuilder()
+    .enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
+    .build()
 
   /**
    * Validates a WorkOS Webhook payload and constructs the corresponding event.

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -19,6 +19,7 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
   private val mapper = ObjectMapper().registerModule(KotlinModule.Builder().build())
 
   init {
+    mapper.enable(DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE)
     mapper.disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
   }
 

--- a/src/test/kotlin/com/workos/test/directorysync/DirectorySyncApiTest.kt
+++ b/src/test/kotlin/com/workos/test/directorysync/DirectorySyncApiTest.kt
@@ -227,6 +227,59 @@ class DirectorySyncApiTest : TestBase() {
   }
 
   @Test
+  fun listDirectoriesHandlesUnknownDirectoryTypes() {
+    val workos = createWorkOSClient()
+
+    val unknownDirectoryId = "directory_01ECAZ4NV9QMV47GW873HDCX74"
+    val oktaDirectoryId = "directory_01E8CS3GSBEBZ1F1CZAEE3KHDG"
+
+    stubResponse(
+      url = "/directories",
+      responseBody = """{
+        "data": [{
+          "id": "$unknownDirectoryId",
+          "idp_id": "02grqrue4294w24",
+          "domain": "foo-corp.com",
+          "external_key": "abcdefghi",
+          "name": "Foo Corp",
+          "organization_id": "org_01EHZNVPK3SFK441A1RGBFSHRT",
+          "object": "directory",
+          "state": "unlinked",
+          "type": "unknown type",
+          "created_at": "2021-06-25T19:07:33.155Z",
+          "updated_at": "2021-06-25T19:08:33.155Z"
+        },
+        {
+          "id": "$oktaDirectoryId",
+          "domain": "foo-corp.com",
+          "external_key": "r3NDlInUnAe6i4wG",
+          "name": "Foo Corp",
+          "organization_id": "org_01EHZNVPK3SFK441A1RGBFPANT",
+          "object": "directory",
+          "state": "linked",
+          "type": "okta scim v2.0",
+          "created_at": "2021-06-25T19:09:33.155Z",
+          "updated_at": "2021-06-25T19:10:33.155Z"
+        }],
+        "list_metadata" : {
+          "after" : "someAfterId",
+          "before" : "someBeforeId"
+        }
+      }""",
+    )
+
+    val (data) = workos.directorySync.listDirectories()
+
+    val unknownDirectory = data[0]
+    val oktaDirectory = data[1]
+
+    assertEquals(unknownDirectory.id, unknownDirectoryId)
+    assertEquals(unknownDirectory.type, DirectoryType.Unknown)
+    assertEquals(oktaDirectory.id, oktaDirectoryId)
+    assertEquals(oktaDirectory.type, DirectoryType.OktaSCIMV2_0)
+  }
+
+  @Test
   fun getDirectoryUserShouldReturnDirectoryUser() {
     val workos = createWorkOSClient()
 

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryWebhookTests.kt
@@ -49,6 +49,40 @@ class DirectoryWebhookTests : TestBase() {
   }
 
   @Test
+  fun constructDirectoryActivatedEventWithUnknownDirectoryType() {
+    val workos = createWorkOSClient()
+    val webhookData =
+      """
+      {
+        "id": "$webhookId",
+        "data": {
+          "id": "$directoryId",
+          "name": "F",
+          "type": "unknown directory",
+          "state": "linked",
+          "object": "directory",
+          "created_at": "2021-11-20T10:15:50.695Z",
+          "updated_at": "2021-11-20T10:16:26.921Z",
+          "organization_id": "org_01FKPWZWPHE9VN2QXJ7G1BZYP8"
+        },
+        "event": "${EventType.DirectoryActivated.value}"
+      }
+      """
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is DirectoryActivatedEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as DirectoryActivatedEvent).data.id, directoryId)
+    assertEquals((webhook as DirectoryActivatedEvent).data.type, DirectoryType.Unknown)
+  }
+
+  @Test
   fun constructDirectoryDirectoryDeactivatedEvent() {
     val workos = createWorkOSClient()
     val webhookData = generateGroupWebhookEvent(EventType.DirectoryDeactivated)

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryWebhookTests.kt
@@ -67,7 +67,8 @@ class DirectoryWebhookTests : TestBase() {
           "updated_at": "2021-11-20T10:16:26.921Z",
           "organization_id": "org_01FKPWZWPHE9VN2QXJ7G1BZYP8"
         },
-        "event": "${EventType.DirectoryActivated.value}"
+        "event": "${EventType.DirectoryActivated.value}",
+        "created_at": "2021-11-20T10:15:50.695Z"
       }
       """
     val testData = WebhooksApiTest.prepareTest(webhookData)

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryWebhookTests.kt
@@ -1,5 +1,6 @@
 package com.workos.test.webhooks
 
+import com.workos.directorysync.models.DirectoryType
 import com.workos.test.TestBase
 import com.workos.webhooks.models.* // ktlint-disable no-wildcard-imports
 import org.junit.Test


### PR DESCRIPTION
## Description

This PR adds support for handling unknown `DirectoryType` values when deserializing from JSON.

Currently anytime a response comes back with an unknown `DirectoryType` value the deserialization will fail with an exception. This can cause problems when new directory types are added to the API that are not present in the SDK.

To remedy this, a new `Unknown` member has been added to the `DirectoryType` enum that is denoted as the `@ JsonEnumDefaultValue`. This—combined with the `DeserializationFeature.READ_UNKNOWN_ENUM_VALUES_USING_DEFAULT_VALUE`—makes it so we use `DirectoryType::Unknown` whenever there is a value that we don't recognize.

For reference, I was following the example in [this article](https://blog.wpanas.eu/posts/best-way-to-handle-unkown-enum-values-using-jackson/).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
