### PR TITLE
Add actorIds parameter to createExport

### DIFF
--- a/src/main/kotlin/com/workos/auditlogs/AuditLogsApi.kt
+++ b/src/main/kotlin/com/workos/auditlogs/AuditLogsApi.kt
@@ -245,7 +245,11 @@ class AuditLogsApi(private val workos: WorkOS) {
     val rangeEnd: Date,
     val actions: List<String>?,
     val actors: List<String>?,
-    val targets: List<String>?
+    val targets: List<String>?,
+    @JsonProperty("actor_names")
+    val actorNames: List<String>?,
+    @JsonProperty("actor_ids")
+    val actorIds: List<String>?
   ) {
     /**
      * Builder class for [CreateAuditLogExportOptions].
@@ -256,6 +260,8 @@ class AuditLogsApi(private val workos: WorkOS) {
       private var rangeEnd: Date? = null
       private var actions: List<String>? = null
       private var actors: List<String>? = null
+      private var actorNames: List<String>? = null
+      private var actorIds: List<String>? = null
       private var targets: List<String>? = null
 
       /**
@@ -281,7 +287,18 @@ class AuditLogsApi(private val workos: WorkOS) {
       /**
        * Sets the actors export filter.
        */
+      @Deprecated("Use the new actorNames() method")
       fun actors(value: List<String>) = apply { actors = value }
+
+      /**
+       * Sets the actorNames export filter.
+       */
+      fun actorNames(value: List<String>) = apply { actorNames = value }
+
+      /**
+       * Sets the actorIds export filter.
+       */
+      fun actorIds(value: List<String>) = apply { actorIds = value }
 
       /**
        * Sets the targets export filter.
@@ -310,7 +327,9 @@ class AuditLogsApi(private val workos: WorkOS) {
           rangeEnd = rangeEnd!!,
           actions = actions,
           actors = actors,
-          targets = targets
+          targets = targets,
+          actorNames = actorNames,
+          actorIds = actorIds,
         )
       }
     }

--- a/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
+++ b/src/test/kotlin/com/workos/test/auditlogs/AuditLogsTest.kt
@@ -308,6 +308,8 @@ class AuditLogsTest : TestBase() {
         "range_end": "2022-09-17T19:58:50.686Z",
         "actions": ["foo", "bar"],
         "actors": ["foo", "bar"],
+        "actor_names": ["foo", "bar"],
+        "actor_ids": ["user_foo", "user_bar"],
         "targets": ["foo", "bar"]
       }"""
     )
@@ -318,6 +320,8 @@ class AuditLogsTest : TestBase() {
       .rangeEnd(Date(1663444730686))
       .actions(listOf("foo", "bar"))
       .actors(listOf("foo", "bar"))
+      .actorNames(listOf("foo", "bar"))
+      .actorIds(listOf("user_foo", "user_bar"))
       .targets(listOf("foo", "bar"))
       .build()
 


### PR DESCRIPTION
## Description

- Adds `actor_names` parameter on `CreateAuditLogExportOptionsBuilder`
- Adds `actor_ids` parameter on `CreateAuditLogExportOptionsBuilder`
- Deprecates `actors` parameter on `CreateAuditLogExportOptionsBuilder`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
