### PR TITLE
Allow raw_attributes to be nullable in Group object

### DIFF
--- a/src/main/kotlin/com/workos/directorysync/models/Group.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/Group.kt
@@ -49,5 +49,5 @@ open class Group
 
   @JvmField
   @JsonProperty("raw_attributes")
-  open val rawAttributes: Map<String, Any?>
+  open val rawAttributes: Map<String, Any?>?
 )


### PR DESCRIPTION
## Description
Make raw_attributes to be nullable in Group object

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
