### PR TITLE
Remove "suspended" state from Directory Sync user object

### DIFF
--- a/src/main/kotlin/com/workos/directorysync/models/UserState.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/UserState.kt
@@ -16,10 +16,5 @@ enum class UserState(@JsonValue val state: String) {
   /**
    * The user is inactive.
    */
-  Inactive("inactive"),
-
-  /**
-   * The user is suspended.
-   */
-  Suspended("suspended")
+  Inactive("inactive")
 }


### PR DESCRIPTION
## Description
"suspended" state is now deprecated and consolidated into the "inactive" state


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
