### PR TITLE
Add GitHub Actions as the CI runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ defaults:
     shell: bash
 
 jobs:
-  test:
-    name: Test Kotlin
+  build:
+    name: Build Kotlin SDK
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -20,6 +20,11 @@ jobs:
         run: |
           ./gradlew build
 
+  test:
+    name: Test Kotlin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
       - name: Test
         run: |
           ./gradlew test --info

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches:
+      - 'main'
+  pull_request: {}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  test:
+    name: Test Kotlin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build
+        run: |
+          ./gradlew build
+
+      - name: Test
+        run: |
+          ./gradlew test --info

--- a/src/test/kotlin/com/workos/test/portal/PortalApiTest.kt
+++ b/src/test/kotlin/com/workos/test/portal/PortalApiTest.kt
@@ -44,6 +44,7 @@ class PortalApiTest : TestBase() {
     val response = workos.portal.generateLink(options)
 
     assertEquals(response.link, portalLink)
+    assertEquals(1, 2)
   }
 
   @Test

--- a/src/test/kotlin/com/workos/test/portal/PortalApiTest.kt
+++ b/src/test/kotlin/com/workos/test/portal/PortalApiTest.kt
@@ -44,7 +44,6 @@ class PortalApiTest : TestBase() {
     val response = workos.portal.generateLink(options)
 
     assertEquals(response.link, portalLink)
-    assertEquals(1, 2)
   }
 
   @Test


### PR DESCRIPTION
## Description
We are working on consolidating all CI to GitHub Actions.

I did not port the "artifact push job" line of Semaphore as that hasn't been working anyway.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
