### PR TITLE
Add usermanagement.getAuthorizationUrl

### DIFF
--- a/src/main/kotlin/com/workos/WorkOS.kt
+++ b/src/main/kotlin/com/workos/WorkOS.kt
@@ -21,6 +21,7 @@ import com.workos.organizations.OrganizationsApi
 import com.workos.passwordless.PasswordlessApi
 import com.workos.portal.PortalApi
 import com.workos.sso.SsoApi
+import com.workos.usermanagement.UserManagementApi
 import com.workos.webhooks.WebhooksApi
 import org.apache.http.client.utils.URIBuilder
 import java.lang.IllegalArgumentException
@@ -94,6 +95,12 @@ class WorkOS(
    */
   @JvmField
   val mfa = MfaApi(this)
+
+  /**
+   * Module for interacting with the User Management API.
+   */
+  @JvmField
+  val usermanagement = UserManagementApi(this)
 
   /**
    * Module for interacting with the Webhooks API.

--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -1,0 +1,106 @@
+package com.workos.usermanagement
+import com.workos.WorkOS
+import org.apache.http.client.utils.URIBuilder
+
+class UserManagementApi(private val workos: WorkOS) {
+  /**
+   * Builder for authorization URLs. Can be created via [getAuthorizationUrl] method.
+   *
+   * @param baseUrl The base URL to retrieve the OAuth 2.0 authorization from.
+   * @param clientId This value can be obtained from the Configuration page in the WorkOS dashboard.
+   * @param redirectUri A redirect URI to return an authorized user to.
+   * @param connection Connection ID to determine which identity provider to authenticate with.
+   * @param domain Use the domain to determine which connection and identity provider to authenticate with.
+   * @param provider Name of the identity provider e.g. GitHubOAuth, GoogleOAuth, or MicrosoftOAuth.
+   * @param state User defined information to persist application data between redirects.
+   */
+  class AuthorizationUrlOptionsBuilder @JvmOverloads constructor(
+    val baseUrl: String,
+    val clientId: String,
+    val redirectUri: String,
+    var connectionId: String? = null,
+    var domainHint: String? = null,
+    var loginHint: String? = null,
+    var organizationId: String? = null,
+    var provider: String? = null,
+    var state: String? = null
+  ) {
+    /**
+     * Connection ID.
+     */
+    fun connectionId(value: String) = apply { connectionId = value }
+
+    /**
+     * Domain Hint
+     */
+    fun domainHint(value: String) = apply { domainHint = value }
+
+    /**
+     * Login Hint
+     */
+    fun loginHint(value: String) = apply { loginHint = value }
+
+    /**
+     * Organization ID
+     */
+    fun organizationId(value: String) = apply { organizationId = value }
+
+    /**
+     * Value used to authenticate all users with the same connection and Identity Provider.
+     *
+     * Currently, the only supported values for provider are GitHubOAuth, GoogleOAuth, and
+     * MicrosoftOAuth. Provide the provider parameter when authenticating Google OAuth
+     * users, because Google OAuth does not take a user’s domain into account when logging
+     * in with a “Sign in with Google” button.
+     */
+    fun provider(value: String) = apply { provider = value }
+
+    /**
+     * Optional parameter that a Developer can choose to include in their authorization URL.
+     * If included, then the redirect URI received from WorkOS will contain the exact state
+     * that was passed in the authorization URL.
+     *
+     * The state parameter can be used to encode arbitrary information to help restore
+     * application state between redirects.
+     */
+    fun state(value: String) = apply { state = value }
+
+    /**
+     * Generates the URL based on the given options.
+     */
+    fun build(): String {
+      val uriBuilder = URIBuilder("$baseUrl")
+        .setPath("/user_management/authorize")
+        .addParameter("client_id", clientId)
+        .addParameter("redirect_uri", redirectUri)
+        .addParameter("response_type", "code")
+
+      if (connectionId != null) uriBuilder.addParameter("connection_id", connectionId)
+      if (domainHint != null) uriBuilder.addParameter("domain_hint", domainHint)
+      if (loginHint != null) uriBuilder.addParameter("login_hint", loginHint)
+      if (organizationId != null) uriBuilder.addParameter("organization_id", organizationId)
+      if (provider != null) uriBuilder.addParameter("provider", provider)
+      if (state != null) uriBuilder.addParameter("state", state)
+
+      return uriBuilder.toString()
+    }
+
+    /**
+     * @suppress
+     */
+    companion object {
+      @JvmStatic
+      fun create(baseUrl: String, clientId: String, redirectUri: String): AuthorizationUrlOptionsBuilder {
+        return AuthorizationUrlOptionsBuilder(baseUrl, clientId, redirectUri)
+      }
+    }
+  }
+
+  /**
+   * Generate an Oauth2 authorization URL where your users will
+   * authenticate using the configured SSO Identity Provider.
+   */
+  fun getAuthorizationUrl(clientId: String, redirectUri: String): AuthorizationUrlOptionsBuilder {
+    return AuthorizationUrlOptionsBuilder.create(workos.baseUrl, clientId, redirectUri)
+  }
+}

--- a/src/test/kotlin/com/workos/test/usermanagement/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/usermanagement/UserManagementApiTest.kt
@@ -1,0 +1,35 @@
+package com.workos.test.usermanagement
+
+import com.workos.test.TestBase
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class UserManagementApiTest : TestBase() {
+  @Test
+  fun getAuthorizationUrlShouldReturnValidUrl() {
+    val workos = createWorkOSClient()
+
+    val url = workos.usermanagement.getAuthorizationUrl("client_id", "http://localhost:8080/redirect").build()
+
+    assertEquals(
+      "http://localhost:${getWireMockPort()}/user_management/authorize?client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fredirect&response_type=code",
+      url
+    )
+  }
+
+  @Test
+  fun getAuthorizationUrlShouldAcceptAdditionalParams() {
+    val workos = createWorkOSClient()
+
+    val url = workos.usermanagement.getAuthorizationUrl("client_id", "http://localhost:8080/redirect")
+      .connectionId("connection_value")
+      .provider("provider_value")
+      .state("state_value")
+      .build()
+
+    assertEquals(
+      "http://localhost:${getWireMockPort()}/user_management/authorize?client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fredirect&response_type=code&connection_id=connection_value&provider=provider_value&state=state_value",
+      url
+    )
+  }
+}


### PR DESCRIPTION
## Description

Adds usermanagement.getAuthorizeUrl

This is mostly a copy-paste of sso.getAuthorizeUrl (a few parameters have been renamed, and I removed the deprecated `domain` param).

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
