### PR TITLE
Trigger Maven publish for pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,9 +3,9 @@ name: Release
 on:
   # Support manually pushing a new release
   workflow_dispatch: {}
-  # Trigger when a release is published
+  # Trigger when a release or pre-release is published
   release:
-    types: [released]
+    types: [published]
 
 defaults:
   run:


### PR DESCRIPTION
## Description
Trigger Maven publish for pre-releases.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
