### PR TITLE
Add events and API changes for invitations and Magic Auth

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -20,12 +20,14 @@ import com.workos.usermanagement.models.EnrolledAuthenticationFactor
 import com.workos.usermanagement.models.Identity
 import com.workos.usermanagement.models.Invitation
 import com.workos.usermanagement.models.Invitations
+import com.workos.usermanagement.models.MagicAuth
 import com.workos.usermanagement.models.OrganizationMembership
 import com.workos.usermanagement.models.OrganizationMemberships
 import com.workos.usermanagement.models.RefreshAuthentication
 import com.workos.usermanagement.models.User
 import com.workos.usermanagement.models.Users
 import com.workos.usermanagement.types.AuthenticationAdditionalOptions
+import com.workos.usermanagement.types.CreateMagicAuthOptions
 import com.workos.usermanagement.types.CreateOrganizationMembershipOptions
 import com.workos.usermanagement.types.CreateUserOptions
 import com.workos.usermanagement.types.EnrolledAuthenticationFactorOptions
@@ -214,9 +216,28 @@ class UserManagementApi(private val workos: WorkOS) {
   }
 
   /**
+   * Get the details of an existing Magic Auth code.
+   */
+  fun getMagicAuth(id: String): MagicAuth {
+    return workos.get("/user_management/magic_auth/$id", MagicAuth::class.java)
+  }
+
+  /**
+   * Creates a Magic Auth code that can be used to authenticate into your app.
+   */
+  fun createMagicAuth(options: CreateMagicAuthOptions): MagicAuth {
+    return workos.post(
+      "/user_management/magic_auth",
+      MagicAuth::class.java,
+      RequestConfig.builder().data(options).build()
+    )
+  }
+
+  /**
    * Sends a one-time authentication code to the user’s email address. The code
    * expires in 10 minutes. To verify the code, authenticate the user with Magic Auth.
    */
+  @Deprecated("Please use `createMagicAuth` instead. This method will be removed in a future major version.")
   fun sendMagicAuthCode(email: String) {
     workos.post(
       "/user_management/magic_auth/send",

--- a/src/main/kotlin/com/workos/usermanagement/builders/CreateMagicAuthOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/CreateMagicAuthOptionsBuilder.kt
@@ -1,0 +1,39 @@
+package com.workos.usermanagement.builders
+
+import com.workos.usermanagement.types.CreateMagicAuthOptions
+
+/**
+ * Builder for options when creating a Magic Auth code.
+ *
+ * @param email The email address of the user.
+ * @param invitationToken The token of an invitation, if required.
+ */
+class CreateMagicAuthOptionsBuilder @JvmOverloads constructor(
+  private var email: String,
+  private var invitationToken: String? = null,
+) {
+  /**
+   * Invitation Token
+   */
+  fun invitationToken(value: String) = apply { invitationToken = value }
+
+  /**
+   * Generates the CreateMagicAuthOptions object.
+   */
+  fun build(): CreateMagicAuthOptions {
+    return CreateMagicAuthOptions(
+      email = this.email,
+      invitationToken = this.invitationToken,
+    )
+  }
+
+  /**
+   * @suppress
+   */
+  companion object {
+    @JvmStatic
+    fun create(email: String): CreateMagicAuthOptionsBuilder {
+      return CreateMagicAuthOptionsBuilder(email)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/usermanagement/models/InvitationEvent.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/InvitationEvent.kt
@@ -15,13 +15,11 @@ import com.workos.usermanagement.types.InvitationStateEnumType
  * @param acceptedAt The timestamp when the invitation was accepted.
  * @param revokedAt The timestamp when the invitation was revoked.
  * @param expiresAt The timestamp when the invitation will expire.
- * @param token The token of an invitation.
- * @param acceptInvitationUrl The URL where the user can accept the invitation.
  * @param organizationId The ID of the organization.
  * @param createdAt The timestamp when the invitation was created.
  * @param updatedAt The timestamp when the invitation was last updated.
  */
-data class Invitation @JsonCreator constructor(
+data class InvitationEvent @JsonCreator constructor(
   @JsonProperty("id")
   val id: String,
 
@@ -39,12 +37,6 @@ data class Invitation @JsonCreator constructor(
 
   @JsonProperty("expires_at")
   val expiresAt: String,
-
-  @JsonProperty("token")
-  val token: String,
-
-  @JsonProperty("accept_invitation_url")
-  val acceptInvitationUrl: String,
 
   @JsonProperty("organization_id")
   val organizationId: String? = null,

--- a/src/main/kotlin/com/workos/usermanagement/models/InvitationEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/InvitationEventData.kt
@@ -19,7 +19,7 @@ import com.workos.usermanagement.types.InvitationStateEnumType
  * @param createdAt The timestamp when the invitation was created.
  * @param updatedAt The timestamp when the invitation was last updated.
  */
-data class InvitationEvent @JsonCreator constructor(
+data class InvitationEventData @JsonCreator constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/models/MagicAuth.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/MagicAuth.kt
@@ -1,0 +1,38 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * A Magic Auth code that allows the recipient to authenticate to your app
+ *
+ * @param id The unique ID of the Magic Auth code.
+ * @param userId The unique ID of the user.
+ * @param email The email address of the user.
+ * @param expiresAt The timestamp when the Magic Auth code will expire.
+ * @param code The Magic Auth code.
+ * @param createdAt The timestamp when the Magic Auth code was created.
+ * @param updatedAt The timestamp when the Magic Auth code was last updated.
+ */
+data class MagicAuth @JsonCreator constructor(
+  @JsonProperty("id")
+  val id: String,
+
+  @JsonProperty("user_id")
+  val userId: String,
+
+  @JsonProperty("email")
+  val email: String,
+
+  @JsonProperty("expires_at")
+  val expiresAt: String,
+
+  @JsonProperty("code")
+  val code: String,
+
+  @JsonProperty("created_at")
+  val createdAt: String,
+
+  @JsonProperty("updated_at")
+  val updatedAt: String
+)

--- a/src/main/kotlin/com/workos/usermanagement/models/MagicAuthEvent.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/MagicAuthEvent.kt
@@ -1,0 +1,34 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * A Magic Auth code that allows the recipient to authenticate to your app
+ *
+ * @param id The unique ID of the Magic Auth code.
+ * @param userId The unique ID of the user.
+ * @param email The email address of the user.
+ * @param expiresAt The timestamp when the Magic Auth code will expire.
+ * @param createdAt The timestamp when the Magic Auth code was created.
+ * @param updatedAt The timestamp when the Magic Auth code was last updated.
+ */
+data class MagicAuthEvent @JsonCreator constructor(
+  @JsonProperty("id")
+  val id: String,
+
+  @JsonProperty("user_id")
+  val userId: String,
+
+  @JsonProperty("email")
+  val email: String,
+
+  @JsonProperty("expires_at")
+  val expiresAt: String,
+
+  @JsonProperty("created_at")
+  val createdAt: String,
+
+  @JsonProperty("updated_at")
+  val updatedAt: String
+)

--- a/src/main/kotlin/com/workos/usermanagement/models/MagicAuthEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/MagicAuthEventData.kt
@@ -13,7 +13,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param createdAt The timestamp when the Magic Auth code was created.
  * @param updatedAt The timestamp when the Magic Auth code was last updated.
  */
-data class MagicAuthEvent @JsonCreator constructor(
+data class MagicAuthEventData @JsonCreator constructor(
   @JsonProperty("id")
   val id: String,
 

--- a/src/main/kotlin/com/workos/usermanagement/types/CreateMagicAuthOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/CreateMagicAuthOptions.kt
@@ -1,0 +1,21 @@
+package com.workos.usermanagement.types
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class CreateMagicAuthOptions(
+  /**
+   * The email address of the user.
+   */
+  @JsonProperty("email")
+  val email: String,
+
+  /**
+   * The token of an invitation, if required.
+   */
+  @JsonProperty("invitation_token")
+  val invitationToken: String? = null,
+) {
+  init {
+    require(email.isNotBlank()) { "Email is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/webhooks/models/EventType.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/EventType.kt
@@ -82,9 +82,19 @@ enum class EventType(
   DirectoryGroupDeleted("dsync.group.deleted"),
 
   /**
+   * Triggers when a user is invited to sign up or to join an organization.
+   */
+  InvitationCreated("invitation.created"),
+
+  /**
    * Triggers when an organization membership is created.
    */
   OrganizationMembershipCreated("organization_membership.created"),
+
+  /**
+   * Triggers when a user initiates Magic Auth and an authentication code is created.
+   */
+  MagicAuthCreated("magic_auth.created"),
 
   /**
    * Triggers when an organization membership is deleted.

--- a/src/main/kotlin/com/workos/webhooks/models/InvitationEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/InvitationEvent.kt
@@ -1,6 +1,6 @@
 package com.workos.webhooks.models
 
-import com.workos.usermanagement.models.InvitationEvent
+import com.workos.usermanagement.models.InvitationEventData
 
 /**
  * Webhook Event for `invitation.*` events.
@@ -13,7 +13,7 @@ class InvitationEvent(
   override val event: EventType,
 
   @JvmField
-  override val data: InvitationEvent,
+  override val data: InvitationEventData,
 
   @JvmField
   override val createdAt: String

--- a/src/main/kotlin/com/workos/webhooks/models/InvitationEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/InvitationEvent.kt
@@ -1,0 +1,20 @@
+package com.workos.webhooks.models
+
+import com.workos.usermanagement.models.InvitationEvent
+
+/**
+ * Webhook Event for `invitation.*` events.
+ */
+class InvitationEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: InvitationEvent,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/MagicAuthEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/MagicAuthEvent.kt
@@ -1,6 +1,6 @@
 package com.workos.webhooks.models
 
-import com.workos.usermanagement.models.MagicAuthEvent
+import com.workos.usermanagement.models.MagicAuthEventData
 
 /**
  * Webhook Event for `magic_auth.*` events.
@@ -13,7 +13,7 @@ class MagicAuthEvent(
   override val event: EventType,
 
   @JvmField
-  override val data: MagicAuthEvent,
+  override val data: MagicAuthEventData,
 
   @JvmField
   override val createdAt: String

--- a/src/main/kotlin/com/workos/webhooks/models/MagicAuthEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/MagicAuthEvent.kt
@@ -1,0 +1,20 @@
+package com.workos.webhooks.models
+
+import com.workos.usermanagement.models.MagicAuthEvent
+
+/**
+ * Webhook Event for `magic_auth.*` events.
+ */
+class MagicAuthEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: MagicAuthEvent,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -11,8 +11,8 @@ import com.workos.directorysync.models.Directory
 import com.workos.directorysync.models.Group
 import com.workos.directorysync.models.User
 import com.workos.sso.models.Connection
-import com.workos.usermanagement.models.InvitationEvent
-import com.workos.usermanagement.models.MagicAuthEvent
+import com.workos.usermanagement.models.InvitationEventData
+import com.workos.usermanagement.models.MagicAuthEventData
 import com.workos.usermanagement.models.OrganizationMembership
 
 /**
@@ -51,8 +51,8 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
       EventType.DirectoryGroupDeleted -> DirectoryGroupDeletedEvent(id, eventType, deserializeData(data, Group::class.java), createdAt)
       EventType.DirectoryGroupUserAdded -> DirectoryGroupUserAddedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), createdAt)
       EventType.DirectoryGroupUserRemoved -> DirectoryGroupUserRemovedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), createdAt)
-      EventType.InvitationCreated -> InvitationEvent(id, eventType, deserializeData(data, InvitationEvent::class.java), createdAt)
-      EventType.MagicAuthCreated -> MagicAuthEvent(id, eventType, deserializeData(data, MagicAuthEvent::class.java), createdAt)
+      EventType.InvitationCreated -> InvitationEvent(id, eventType, deserializeData(data, InvitationEventData::class.java), createdAt)
+      EventType.MagicAuthCreated -> MagicAuthEvent(id, eventType, deserializeData(data, MagicAuthEventData::class.java), createdAt)
       EventType.OrganizationMembershipCreated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipDeleted -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipUpdated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -11,6 +11,8 @@ import com.workos.directorysync.models.Directory
 import com.workos.directorysync.models.Group
 import com.workos.directorysync.models.User
 import com.workos.sso.models.Connection
+import com.workos.usermanagement.models.InvitationEvent
+import com.workos.usermanagement.models.MagicAuthEvent
 import com.workos.usermanagement.models.OrganizationMembership
 
 /**
@@ -49,6 +51,8 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
       EventType.DirectoryGroupDeleted -> DirectoryGroupDeletedEvent(id, eventType, deserializeData(data, Group::class.java), createdAt)
       EventType.DirectoryGroupUserAdded -> DirectoryGroupUserAddedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), createdAt)
       EventType.DirectoryGroupUserRemoved -> DirectoryGroupUserRemovedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), createdAt)
+      EventType.InvitationCreated -> InvitationEvent(id, eventType, deserializeData(data, InvitationEvent::class.java), createdAt)
+      EventType.MagicAuthCreated -> MagicAuthEvent(id, eventType, deserializeData(data, MagicAuthEvent::class.java), createdAt)
       EventType.OrganizationMembershipCreated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipDeleted -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipUpdated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -4,6 +4,7 @@ import com.workos.common.models.ListMetadata
 import com.workos.common.models.Order
 import com.workos.test.TestBase
 import com.workos.usermanagement.builders.AuthenticationAdditionalOptionsBuilder
+import com.workos.usermanagement.builders.CreateMagicAuthOptionsBuilder
 import com.workos.usermanagement.builders.CreateOrganizationMembershipOptionsBuilder
 import com.workos.usermanagement.builders.CreateUserOptionsBuilder
 import com.workos.usermanagement.builders.EnrolledAuthenticationFactorOptionsBuilder
@@ -18,6 +19,7 @@ import com.workos.usermanagement.models.AuthenticationTotp
 import com.workos.usermanagement.models.EnrolledAuthenticationFactor
 import com.workos.usermanagement.models.Identity
 import com.workos.usermanagement.models.Invitation
+import com.workos.usermanagement.models.MagicAuth
 import com.workos.usermanagement.models.OrganizationMembership
 import com.workos.usermanagement.models.OrganizationMembershipRole
 import com.workos.usermanagement.models.RefreshAuthentication
@@ -656,6 +658,74 @@ class UserManagementApiTest : TestBase() {
   }
 
   @Test
+  fun getMagicAuthShouldReturnValidMagicAuthObject() {
+    stubResponse(
+      "/user_management/magic_auth/magic_auth_123",
+      """{
+        "id": "magic_auth_123",
+        "user_id": "user_123",
+        "email": "test01@example.com",
+        "expires_at": "2021-07-01T19:07:33.155Z",
+        "code": "123456",
+        "created_at": "2021-06-25T19:07:33.155Z",
+        "updated_at": "2021-06-25T19:07:33.155Z"
+      }"""
+    )
+
+    val magicAuth = workos.userManagement.getMagicAuth("magic_auth_123")
+
+    assertEquals(
+      MagicAuth(
+        "magic_auth_123",
+        "user_123",
+        "test01@example.com",
+        "2021-07-01T19:07:33.155Z",
+        "123456",
+        "2021-06-25T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z"
+      ),
+      magicAuth
+    )
+  }
+
+  @Test
+  fun createMagicAuthShouldReturnValidMagicAuthObject() {
+    stubResponse(
+      "/user_management/magic_auth",
+      """{
+        "id": "magic_auth_123",
+        "user_id": "user_123",
+        "email": "test01@example.com",
+        "expires_at": "2021-07-01T19:07:33.155Z",
+        "code": "123456",
+        "created_at": "2021-06-25T19:07:33.155Z",
+        "updated_at": "2021-06-25T19:07:33.155Z"
+      }""",
+      requestBody = """{
+        "email": "test01@example.com"
+      }"""
+    )
+
+    val options = CreateMagicAuthOptionsBuilder("test01@example.com")
+      .build()
+
+    val magicAuth = workos.userManagement.createMagicAuth(options)
+
+    assertEquals(
+      MagicAuth(
+        "magic_auth_123",
+        "user_123",
+        "test01@example.com",
+        "2021-07-01T19:07:33.155Z",
+        "123456",
+        "2021-06-25T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z"
+      ),
+      magicAuth
+    )
+  }
+
+  @Test
   fun sendMagicAuthCodeShouldWorkAndReturnNothing() {
     stubResponse("/user_management/magic_auth/send", "")
 
@@ -1078,7 +1148,8 @@ class UserManagementApiTest : TestBase() {
         "accepted_at": null,
         "revoked_at": null,
         "expires_at": "2021-07-01T19:07:33.155Z",
-        "token": "token",
+        "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "organization_id": "org_456",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
@@ -1095,7 +1166,8 @@ class UserManagementApiTest : TestBase() {
         null,
         null,
         "2021-07-01T19:07:33.155Z",
-        "token",
+        "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
@@ -1117,7 +1189,8 @@ class UserManagementApiTest : TestBase() {
             "accepted_at": null,
             "revoked_at": null,
             "expires_at": "2021-07-01T19:07:33.155Z",
-            "token": "token",
+            "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
             "organization_id": "org_456",
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:07:33.155Z"
@@ -1140,7 +1213,8 @@ class UserManagementApiTest : TestBase() {
         null,
         null,
         "2021-07-01T19:07:33.155Z",
-        "token",
+        "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
@@ -1168,7 +1242,8 @@ class UserManagementApiTest : TestBase() {
             "accepted_at": null,
             "revoked_at": null,
             "expires_at": "2021-07-01T19:07:33.155Z",
-            "token": "token",
+            "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
             "organization_id": "org_456",
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:07:33.155Z"
@@ -1200,7 +1275,8 @@ class UserManagementApiTest : TestBase() {
         null,
         null,
         "2021-07-01T19:07:33.155Z",
-        "token",
+        "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
@@ -1226,7 +1302,8 @@ class UserManagementApiTest : TestBase() {
         "accepted_at": null,
         "revoked_at": null,
         "expires_at": "2021-07-01T19:07:33.155Z",
-        "token": "token",
+        "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "organization_id": "org_456",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
@@ -1257,7 +1334,8 @@ class UserManagementApiTest : TestBase() {
         null,
         null,
         "2021-07-01T19:07:33.155Z",
-        "token",
+        "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
@@ -1267,7 +1345,7 @@ class UserManagementApiTest : TestBase() {
   }
 
   @Test
-  fun deleteInvitationShouldWorkAndReturnNothing() {
+  fun revokeInvitationShouldWorkAndReturnValidInvitation() {
     stubResponse(
       "/user_management/invitations/invitation_123/revoke",
       """{
@@ -1277,7 +1355,8 @@ class UserManagementApiTest : TestBase() {
         "accepted_at": null,
         "revoked_at": "2021-08-01T19:07:33.155Z",
         "expires_at": "2021-07-01T19:07:33.155Z",
-        "token": "token",
+        "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "organization_id": "org_456",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
@@ -1294,7 +1373,8 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-08-01T19:07:33.155Z",
         "2021-07-01T19:07:33.155Z",
-        "token",
+        "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -702,12 +702,12 @@ class UserManagementApiTest : TestBase() {
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
       requestBody = """{
-        "email": "test01@example.com"
+        "email": "test01@example.com",
+        "invitation_token": null
       }"""
     )
 
-    val options = CreateMagicAuthOptionsBuilder("test01@example.com")
-      .build()
+    val options = CreateMagicAuthOptionsBuilder("test01@example.com").build()
 
     val magicAuth = workos.userManagement.createMagicAuth(options)
 

--- a/src/test/kotlin/com/workos/test/webhooks/InvitationWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/InvitationWebhookTests.kt
@@ -1,0 +1,53 @@
+package com.workos.test.webhooks
+
+import com.workos.test.TestBase
+import com.workos.webhooks.models.EventType
+import com.workos.webhooks.models.InvitationEvent
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import kotlin.test.assertEquals
+
+class InvitationWebhookTests : TestBase() {
+
+  private val invitationId = "invitation_01EHWNC0FCBHZ3BJ7EGKYXK0E7"
+  private val webhookId = "wh_01FMXJ2W7T9VY7EAHHMBF2K07Y"
+
+  private fun generateWebhookEvent(eventType: EventType): String {
+    return """
+    {
+      "id": "$webhookId",
+      "event": "${eventType.value}",
+      "data": {
+        "object": "invitation",
+        "id": "$invitationId",
+        "email": "marcelina@foo-corp.com",
+        "state": "pending",
+        "accepted_at": null,
+        "revoked_at": null,
+        "expires_at": "2023-11-27T19:07:33.155Z",
+        "organization_id": "org_01EHWNCE74X7JSDV0X3SZ3KJNY",
+        "created_at": "2023-11-27T19:07:33.155Z",
+        "updated_at": "2023-11-27T19:07:33.155Z"
+      },
+      "created_at": "2023-11-27T19:07:33.155Z"
+    }
+    """
+  }
+
+  @Test
+  fun constructInvitationCreatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.InvitationCreated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is InvitationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as InvitationEvent).data.id, invitationId)
+  }
+}

--- a/src/test/kotlin/com/workos/test/webhooks/MagicAuthWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/MagicAuthWebhookTests.kt
@@ -1,0 +1,50 @@
+package com.workos.test.webhooks
+
+import com.workos.test.TestBase
+import com.workos.webhooks.models.EventType
+import com.workos.webhooks.models.MagicAuthEvent
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import kotlin.test.assertEquals
+
+class MagicAuthWebhookTests : TestBase() {
+
+  private val magicAuthId = "magic_auth_01EHWNC0FCBHZ3BJ7EGKYXK0E7"
+  private val webhookId = "wh_01FMXJ2W7T9VY7EAHHMBF2K07Y"
+
+  private fun generateWebhookEvent(eventType: EventType): String {
+    return """
+    {
+      "id": "$webhookId",
+      "event": "${eventType.value}",
+      "data": {
+        "object": "magic_auth",
+        "id": "$magicAuthId",
+        "user_id": "user_01HWZBQAY251RZ9BKB4RZW4D4A",
+        "email": "marcelina@foo-corp.com",
+        "expires_at": "2023-11-27T19:07:33.155Z",
+        "created_at": "2023-11-27T19:07:33.155Z",
+        "updated_at": "2023-11-27T19:07:33.155Z"
+      },
+      "created_at": "2023-11-27T19:07:33.155Z"
+    }
+    """
+  }
+
+  @Test
+  fun constructMagicAuthCreatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.MagicAuthCreated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is MagicAuthEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as MagicAuthEvent).data.id, magicAuthId)
+  }
+}


### PR DESCRIPTION
## Description

Adds events and API changes to support sending your own emails for invitations and Magic Auth.

- Adds `acceptInvitationUrl` to invitation object returned by API
- Adds new endpoints for the Magic Auth API: `getMagicAuth` and `createMagicAuth`
- Deprecates current `sendMagicAuthCode` method in favor of `createMagicAuth`
- Adds new events for `invitation.created` and `magic_auth.created`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/26691