### PR TITLE
Add `domainData` to Organization create and update methods, replacing deprecated `domains`

### DIFF
--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -14,12 +14,26 @@ import com.workos.organizations.models.OrganizationList
  * The OrganizationsApi provides convenience methods for working with WorkOS Organizations.
  */
 class OrganizationsApi(private val workos: WorkOS) {
+  class OrganizationDomainDataOptions @JvmOverloads constructor(
+    val domain: String,
+    val state: OrganizationDomainDataState
+  )
+
+  enum class OrganizationDomainDataState {
+    @JsonProperty("verified")
+    VERIFIED,
+
+    @JsonProperty("pending")
+    PENDING
+  }
+
   /**
    * Parameters for [createOrganization].
    * Use `CreateOrganizationOptions.builder()` to create a new builder instance.
    *
    * @param name The name of the organization.
    * @param allowProfilesOutsideOrganization Whether the Connections within this Organization should allow Profiles that do not have a domain that is present in the set of the Organization's User Email Domains.
+   * @param domainData A list of data for the domains of the organization.
    * @param domains A list of domains for the organization.
    */
   @JsonInclude(Include.NON_NULL)
@@ -29,8 +43,10 @@ class OrganizationsApi(private val workos: WorkOS) {
     @JsonProperty("allow_profiles_outside_organization")
     val allowProfilesOutsideOrganization: Boolean? = null,
 
-    val domains: List<String>? = null
+    @JsonProperty("domain_data")
+    val domainData: List<OrganizationDomainDataOptions>? = null,
 
+    val domains: List<String>? = null
   ) {
     /**
      * Builder class for creating [CreateOrganizationOptions].
@@ -39,6 +55,8 @@ class OrganizationsApi(private val workos: WorkOS) {
       private var name: String? = null
 
       private var allowProfilesOutsideOrganization: Boolean? = null
+
+      private var domainData: List<OrganizationDomainDataOptions>? = null
 
       private var domains: List<String>? = null
 
@@ -53,6 +71,11 @@ class OrganizationsApi(private val workos: WorkOS) {
       fun allowProfilesOutsideOrganization(value: Boolean) = apply { allowProfilesOutsideOrganization = value }
 
       /**
+       * Sets the list of domain data for the organization.
+       */
+      fun domainData(value: List<OrganizationDomainDataOptions>) = apply { domainData = value }
+
+      /**
        * Sets the list of domains for the organization.
        */
       fun domains(value: List<String>) = apply { domains = value }
@@ -61,7 +84,7 @@ class OrganizationsApi(private val workos: WorkOS) {
        * Creates an instance of [CreateOrganizationOptions] with the given params.
        */
       fun build(): CreateOrganizationOptions {
-        return CreateOrganizationOptions(name, allowProfilesOutsideOrganization, domains)
+        return CreateOrganizationOptions(name, allowProfilesOutsideOrganization, domainData, domains)
       }
     }
 
@@ -203,6 +226,7 @@ class OrganizationsApi(private val workos: WorkOS) {
    *
    * @param name The name of the organization.
    * @param allowProfilesOutsideOrganization Whether the Connections within this Organization should allow Profiles that do not have a domain that is present in the set of the Organization's User Email Domains.
+   * @param domainData A list of data for the domains of the organization.
    * @param domains A list of domains for the organization.
    */
   @JsonInclude(Include.NON_NULL)
@@ -211,6 +235,9 @@ class OrganizationsApi(private val workos: WorkOS) {
 
     @JsonProperty("allow_profiles_outside_organization")
     val allowProfilesOutsideOrganization: Boolean? = null,
+
+    @JsonProperty("domain_data")
+    val domainData: List<OrganizationDomainDataOptions>? = null,
 
     val domains: List<String>? = null
   ) {
@@ -221,6 +248,8 @@ class OrganizationsApi(private val workos: WorkOS) {
       private var name: String? = null
 
       private var allowProfilesOutsideOrganization: Boolean? = null
+
+      private var domainData: List<OrganizationDomainDataOptions>? = null
 
       private var domains: List<String>? = null
 
@@ -235,6 +264,11 @@ class OrganizationsApi(private val workos: WorkOS) {
       fun allowProfilesOutsideOrganization(value: Boolean) = apply { allowProfilesOutsideOrganization = value }
 
       /**
+       * Sets the list of domain data for the organization.
+       */
+      fun domainData(value: List<OrganizationDomainDataOptions>) = apply { domainData = value }
+
+      /**
        * Sets the list of domains for the organization.
        */
       fun domains(value: List<String>) = apply { domains = value }
@@ -243,7 +277,7 @@ class OrganizationsApi(private val workos: WorkOS) {
        * Creates an instance of [UpdateOrganizationOptions].
        */
       fun build(): UpdateOrganizationOptions {
-        return UpdateOrganizationOptions(name, allowProfilesOutsideOrganization, domains)
+        return UpdateOrganizationOptions(name, allowProfilesOutsideOrganization, domainData, domains)
       }
     }
 

--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -14,11 +14,24 @@ import com.workos.organizations.models.OrganizationList
  * The OrganizationsApi provides convenience methods for working with WorkOS Organizations.
  */
 class OrganizationsApi(private val workos: WorkOS) {
+  /**
+   * Options when setting the domains for an organization.
+   *
+   * @param domain The domain of the organization.
+   * @param state The verificaction state of the domain.
+   */
   class OrganizationDomainDataOptions @JvmOverloads constructor(
     val domain: String,
+
     val state: OrganizationDomainDataState
   )
 
+  /**
+   * The verification state of the domain
+   *
+   * @property PENDING The domain is pending verification.
+   * @property VERIFIED The domain has been verified. Pass this if you've already verified the domain through other methods.
+   */
   enum class OrganizationDomainDataState {
     @JsonProperty("verified")
     VERIFIED,

--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -46,6 +46,7 @@ class OrganizationsApi(private val workos: WorkOS) {
     @JsonProperty("domain_data")
     val domainData: List<OrganizationDomainDataOptions>? = null,
 
+    @Deprecated("Use domainData instead.")
     val domains: List<String>? = null
   ) {
     /**
@@ -78,6 +79,7 @@ class OrganizationsApi(private val workos: WorkOS) {
       /**
        * Sets the list of domains for the organization.
        */
+      @Deprecated("Use domainData instead.")
       fun domains(value: List<String>) = apply { domains = value }
 
       /**
@@ -239,6 +241,7 @@ class OrganizationsApi(private val workos: WorkOS) {
     @JsonProperty("domain_data")
     val domainData: List<OrganizationDomainDataOptions>? = null,
 
+    @Deprecated("Use domainData instead.")
     val domains: List<String>? = null
   ) {
     /**
@@ -271,6 +274,7 @@ class OrganizationsApi(private val workos: WorkOS) {
       /**
        * Sets the list of domains for the organization.
        */
+      @Deprecated("Use domainData instead.")
       fun domains(value: List<String>) = apply { domains = value }
 
       /**

--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -9,37 +9,13 @@ import com.workos.common.http.RequestConfig
 import com.workos.common.models.Order
 import com.workos.organizations.models.Organization
 import com.workos.organizations.models.OrganizationList
+import com.workos.organizations.types.OrganizationDomainDataOptions
+import com.workos.organizations.types.OrganizationDomainDataState
 
 /**
  * The OrganizationsApi provides convenience methods for working with WorkOS Organizations.
  */
 class OrganizationsApi(private val workos: WorkOS) {
-  /**
-   * Options when setting the domains for an organization.
-   *
-   * @param domain The domain of the organization.
-   * @param state The verificaction state of the domain.
-   */
-  class OrganizationDomainDataOptions @JvmOverloads constructor(
-    val domain: String,
-
-    val state: OrganizationDomainDataState
-  )
-
-  /**
-   * The verification state of the domain
-   *
-   * @property PENDING The domain is pending verification.
-   * @property VERIFIED The domain has been verified. Pass this if you've already verified the domain through other methods.
-   */
-  enum class OrganizationDomainDataState {
-    @JsonProperty("verified")
-    VERIFIED,
-
-    @JsonProperty("pending")
-    PENDING
-  }
-
   /**
    * Parameters for [createOrganization].
    * Use `CreateOrganizationOptions.builder()` to create a new builder instance.

--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -10,7 +10,6 @@ import com.workos.common.models.Order
 import com.workos.organizations.models.Organization
 import com.workos.organizations.models.OrganizationList
 import com.workos.organizations.types.OrganizationDomainDataOptions
-import com.workos.organizations.types.OrganizationDomainDataState
 
 /**
  * The OrganizationsApi provides convenience methods for working with WorkOS Organizations.

--- a/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataOptions.kt
+++ b/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataOptions.kt
@@ -1,11 +1,11 @@
 package com.workos.organizations.types
 
 /**
-  * Options when setting the domains for an organization.
-  *
-  * @param domain The domain of the organization.
-  * @param state The verificaction state of the domain.
-  */
+ * Options when setting the domains for an organization.
+ *
+ * @param domain The domain of the organization.
+ * @param state The verificaction state of the domain.
+ */
 class OrganizationDomainDataOptions @JvmOverloads constructor(
   val domain: String,
 

--- a/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataOptions.kt
+++ b/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataOptions.kt
@@ -1,0 +1,13 @@
+package com.workos.organizations.types
+
+/**
+  * Options when setting the domains for an organization.
+  *
+  * @param domain The domain of the organization.
+  * @param state The verificaction state of the domain.
+  */
+class OrganizationDomainDataOptions @JvmOverloads constructor(
+  val domain: String,
+
+  val state: OrganizationDomainDataState
+)

--- a/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataState.kt
+++ b/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataState.kt
@@ -3,11 +3,11 @@ package com.workos.organizations.types
 import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
-  * The verification state of the domain
-  *
-  * @property PENDING The domain is pending verification.
-  * @property VERIFIED The domain has been verified. Pass this if you've already verified the domain through other methods.
-  */
+ * The verification state of the domain
+ *
+ * @property Pending The domain is pending verification.
+ * @property Verified The domain has been verified. Pass this if you've already verified the domain through other methods.
+ */
 enum class OrganizationDomainDataState {
   @JsonProperty("verified")
   Verified,

--- a/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataState.kt
+++ b/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataState.kt
@@ -1,0 +1,17 @@
+package com.workos.organizations.types
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+  * The verification state of the domain
+  *
+  * @property PENDING The domain is pending verification.
+  * @property VERIFIED The domain has been verified. Pass this if you've already verified the domain through other methods.
+  */
+enum class OrganizationDomainDataState {
+  @JsonProperty("verified")
+  VERIFIED,
+
+  @JsonProperty("pending")
+  PENDING
+}

--- a/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataState.kt
+++ b/src/main/kotlin/com/workos/organizations/types/OrganizationDomainDataState.kt
@@ -10,8 +10,8 @@ import com.fasterxml.jackson.annotation.JsonProperty
   */
 enum class OrganizationDomainDataState {
   @JsonProperty("verified")
-  VERIFIED,
+  Verified,
 
   @JsonProperty("pending")
-  PENDING
+  Pending
 }

--- a/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
+++ b/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
@@ -5,9 +5,9 @@ import com.workos.common.exceptions.UnauthorizedException
 import com.workos.organizations.OrganizationsApi
 import com.workos.organizations.OrganizationsApi.CreateOrganizationOptions
 import com.workos.organizations.OrganizationsApi.CreateOrganizationRequestOptions
-import com.workos.organizations.OrganizationsApi.OrganizationDomainDataOptions
-import com.workos.organizations.OrganizationsApi.OrganizationDomainDataState
 import com.workos.organizations.OrganizationsApi.UpdateOrganizationOptions
+import com.workos.organizations.types.OrganizationDomainDataOptions
+import com.workos.organizations.types.OrganizationDomainDataState
 import com.workos.test.TestBase
 import org.junit.jupiter.api.Assertions.assertThrows
 import kotlin.test.Test

--- a/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
+++ b/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
@@ -100,6 +100,7 @@ class OrganizationsApiTest : TestBase() {
       CreateOrganizationOptions(
         "Organization Name",
         false,
+        null,
         listOf("foo.com", "bar.com")
       )
     )
@@ -137,6 +138,7 @@ class OrganizationsApiTest : TestBase() {
       CreateOrganizationOptions(
         "Organization Name",
         false,
+        null,
         listOf("foo.com")
       ),
       CreateOrganizationRequestOptions(
@@ -455,6 +457,7 @@ class OrganizationsApiTest : TestBase() {
       UpdateOrganizationOptions(
         "Organization Name",
         false,
+        null,
         listOf("foo.com", "bar.com")
       )
     )

--- a/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
+++ b/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
@@ -81,12 +81,14 @@ class OrganizationsApiTest : TestBase() {
     val config = CreateOrganizationOptions.builder()
       .name("Organization Name")
       .allowProfilesOutsideOrganization(true)
-      .domainData(listOf(
-        OrganizationDomainDataOptions(
-          "example.com",
-          OrganizationDomainDataState.PENDING
+      .domainData(
+        listOf(
+          OrganizationDomainDataOptions(
+            "example.com",
+            OrganizationDomainDataState.PENDING
+          )
         )
-      ))
+      )
       .build()
 
     val organization = workos.organizations.createOrganization(config)
@@ -471,12 +473,14 @@ class OrganizationsApiTest : TestBase() {
     val config = UpdateOrganizationOptions.builder()
       .name("Organization Name")
       .allowProfilesOutsideOrganization(true)
-      .domainData(listOf(
-        OrganizationDomainDataOptions(
-          "example.com",
-          OrganizationDomainDataState.VERIFIED
+      .domainData(
+        listOf(
+          OrganizationDomainDataOptions(
+            "example.com",
+            OrganizationDomainDataState.VERIFIED
+          )
         )
-      ))
+      )
       .build()
 
     val organization = workos.organizations.updateOrganization(data["organizationId"]!!, config)

--- a/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
+++ b/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
@@ -85,7 +85,7 @@ class OrganizationsApiTest : TestBase() {
         listOf(
           OrganizationDomainDataOptions(
             "example.com",
-            OrganizationDomainDataState.PENDING
+            OrganizationDomainDataState.Pending
           )
         )
       )
@@ -151,11 +151,11 @@ class OrganizationsApiTest : TestBase() {
         listOf(
           OrganizationDomainDataOptions(
             "foo.com",
-            OrganizationDomainDataState.PENDING
+            OrganizationDomainDataState.Pending
           ),
           OrganizationDomainDataOptions(
             "bar.com",
-            OrganizationDomainDataState.PENDING
+            OrganizationDomainDataState.Pending
           )
         ),
         null
@@ -477,7 +477,7 @@ class OrganizationsApiTest : TestBase() {
         listOf(
           OrganizationDomainDataOptions(
             "example.com",
-            OrganizationDomainDataState.VERIFIED
+            OrganizationDomainDataState.Verified
           )
         )
       )
@@ -540,11 +540,11 @@ class OrganizationsApiTest : TestBase() {
         listOf(
           OrganizationDomainDataOptions(
             "foo.com",
-            OrganizationDomainDataState.VERIFIED
+            OrganizationDomainDataState.Verified
           ),
           OrganizationDomainDataOptions(
             "bar.com",
-            OrganizationDomainDataState.VERIFIED
+            OrganizationDomainDataState.Verified
           )
         ),
         null,


### PR DESCRIPTION
## Description

Adds a new `domainData` option to be passed to Organization create and update calls, instead of the `domains` parameter which is being deprecated.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
