### PR TITLE
v3.1.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -2,7 +2,7 @@ import java.io.FileOutputStream
 import java.util.Properties
 
 group = "com.workos"
-version = "3.0.1"
+version = "3.1.0"
 
 if (!project.hasProperty("release")) {
   version = "$version-SNAPSHOT"


### PR DESCRIPTION
## Description

Bumps the version to `v3.1.0` and releases the following changes:

* #223

There are other commits on `main` since `v3.0.1`, but only the above appears to be changes to behavior or the public API.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
