### PR TITLE
Add organization membership deactivate and reactivate API methods

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -351,6 +351,20 @@ class UserManagementApi(private val workos: WorkOS) {
   }
 
   /**
+   * Deactivate an organization membership.
+   */
+  fun deactivateOrganizationMembership(id: String): OrganizationMembership {
+    return workos.put("/user_management/organization_memberships/$id/deactivate", OrganizationMembership::class.java)
+  }
+
+  /**
+   * Reactivate an organization membership.
+   */
+  fun reactivateOrganizationMembership(id: String): OrganizationMembership {
+    return workos.put("/user_management/organization_memberships/$id/reactivate", OrganizationMembership::class.java)
+  }
+
+  /**
    * Get the details of an existing invitation.
    */
   fun getInvitation(id: String): Invitation {

--- a/src/main/kotlin/com/workos/usermanagement/builders/ListOrganizationMembershipsOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/ListOrganizationMembershipsOptionsBuilder.kt
@@ -2,12 +2,14 @@ package com.workos.usermanagement.builders
 
 import com.workos.common.models.Order
 import com.workos.usermanagement.types.ListOrganizationMembershipsOptions
+import com.workos.usermanagement.types.OrganizationMembershipStatusEnumType
 
 /**
  * Builder for options when listing organization memberships.
  *
  * @param userId Filter organization memberships by their id.
  * @param organizationId Filter organization memberships by the organization they are members of.
+ * @param statuses Filter organization memberships by the membership status.
  * @param limit Maximum number of records to return.
  * @param before Pagination cursor to receive records before a provided organization membership ID.
  * @param after Pagination cursor to receive records after a provided organization membership ID.
@@ -16,6 +18,7 @@ import com.workos.usermanagement.types.ListOrganizationMembershipsOptions
 class ListOrganizationMembershipsOptionsBuilder @JvmOverloads constructor(
   private var userId: String? = null,
   private var organizationId: String? = null,
+  private var statuses: List<OrganizationMembershipStatusEnumType>? = null,
   private var limit: Int? = null,
   private var before: String? = null,
   private var after: String? = null,
@@ -30,6 +33,11 @@ class ListOrganizationMembershipsOptionsBuilder @JvmOverloads constructor(
    * Organization Id
    */
   fun organizationId(value: String) = apply { organizationId = value }
+
+  /**
+   * Statuses
+   */
+  fun statuses(value: List<OrganizationMembershipStatusEnumType>) = apply { statuses = value }
 
   /**
    * Limit
@@ -58,6 +66,7 @@ class ListOrganizationMembershipsOptionsBuilder @JvmOverloads constructor(
     return ListOrganizationMembershipsOptions(
       userId = this.userId,
       organizationId = this.organizationId,
+      statuses = this.statuses,
       limit = this.limit,
       before = this.before,
       after = this.after,

--- a/src/main/kotlin/com/workos/usermanagement/types/ListOrganizationMembershipsOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/ListOrganizationMembershipsOptions.kt
@@ -12,6 +12,9 @@ class ListOrganizationMembershipsOptions @JvmOverloads constructor(
   @JsonProperty("organization_id")
   val organizationId: String? = null,
 
+  @JsonProperty("statuses")
+  val statuses: List<OrganizationMembershipStatusEnumType>? = null,
+
   @JsonProperty("limit")
   val limit: Int? = null,
 

--- a/src/main/kotlin/com/workos/usermanagement/types/OrganizationMembershipStatusEnumType.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/OrganizationMembershipStatusEnumType.kt
@@ -10,6 +10,12 @@ enum class OrganizationMembershipStatusEnumType(val type: String) {
   Active("active"),
 
   /**
+   * Inactive
+   */
+  @JsonProperty("inactive")
+  Inactive("inactive"),
+
+  /**
    * Pending
    */
   @JsonProperty("pending")

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -1019,6 +1019,12 @@ class UserManagementApiTest : TestBase() {
     val options = ListOrganizationMembershipsOptionsBuilder()
       .userId("id_456")
       .organizationId("org_789")
+      .statuses(
+        listOf<OrganizationMembershipStatusEnumType>(
+          OrganizationMembershipStatusEnumType.Active,
+          OrganizationMembershipStatusEnumType.Inactive
+        )
+      )
       .order(Order.Desc)
       .limit(10)
       .after("someAfterId")
@@ -1135,6 +1141,74 @@ class UserManagementApiTest : TestBase() {
     assertDoesNotThrow() {
       workos.userManagement.deleteOrganizationMembership("om_123")
     }
+  }
+
+  @Test
+  fun deactivateOrganizationMembershipShouldReturnValidOrganizationMembershipObject() {
+    stubResponse(
+      "/user_management/organization_memberships/om_123/deactivate",
+      """{
+        "object": "organization_membership",
+        "id": "om_123",
+        "user_id": "user_456",
+        "organization_id": "org_789",
+        "role": {
+          "slug": "admin"
+        },
+        "status": "inactive",
+        "created_at": "2021-06-25T19:07:33.155Z",
+        "updated_at": "2021-06-25T19:07:33.155Z"
+      }"""
+    )
+
+    val organizationMembership = workos.userManagement.deactivateOrganizationMembership("om_123")
+
+    assertEquals(
+      OrganizationMembership(
+        "om_123",
+        "user_456",
+        "org_789",
+        OrganizationMembershipRole("admin"),
+        OrganizationMembershipStatusEnumType.Inactive,
+        "2021-06-25T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z",
+      ),
+      organizationMembership
+    )
+  }
+
+  @Test
+  fun reactivateOrganizationMembershipShouldReturnValidOrganizationMembershipObject() {
+    stubResponse(
+      "/user_management/organization_memberships/om_123/reactivate",
+      """{
+        "object": "organization_membership",
+        "id": "om_123",
+        "user_id": "user_456",
+        "organization_id": "org_789",
+        "role": {
+          "slug": "admin"
+        },
+        "status": "active",
+        "created_at": "2021-06-25T19:07:33.155Z",
+        "updated_at": "2021-06-25T19:07:33.155Z"
+      }"""
+    )
+
+    val organizationMembership = workos.userManagement.reactivateOrganizationMembership("om_123")
+
+    assertEquals(
+      OrganizationMembership(
+        "om_123",
+        "user_456",
+        "org_789",
+        OrganizationMembershipRole("admin"),
+        OrganizationMembershipStatusEnumType.Active,
+        "2021-06-25T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z",
+      ),
+      organizationMembership
+    )
   }
 
   @Test


### PR DESCRIPTION
## Description
Add organization membership deactivate and reactivate API methods.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
