### PR TITLE
Add methods and events for email verification and password reset

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -16,6 +16,7 @@ import com.workos.usermanagement.builders.SendPasswordResetEmailOptionsBuilder
 import com.workos.usermanagement.builders.UpdateOrganizationMembershipOptionsBuilder
 import com.workos.usermanagement.models.Authentication
 import com.workos.usermanagement.models.AuthenticationFactors
+import com.workos.usermanagement.models.EmailVerification
 import com.workos.usermanagement.models.EnrolledAuthenticationFactor
 import com.workos.usermanagement.models.Identity
 import com.workos.usermanagement.models.Invitation
@@ -23,12 +24,14 @@ import com.workos.usermanagement.models.Invitations
 import com.workos.usermanagement.models.MagicAuth
 import com.workos.usermanagement.models.OrganizationMembership
 import com.workos.usermanagement.models.OrganizationMemberships
+import com.workos.usermanagement.models.PasswordReset
 import com.workos.usermanagement.models.RefreshAuthentication
 import com.workos.usermanagement.models.User
 import com.workos.usermanagement.models.Users
 import com.workos.usermanagement.types.AuthenticationAdditionalOptions
 import com.workos.usermanagement.types.CreateMagicAuthOptions
 import com.workos.usermanagement.types.CreateOrganizationMembershipOptions
+import com.workos.usermanagement.types.CreatePasswordResetOptions
 import com.workos.usermanagement.types.CreateUserOptions
 import com.workos.usermanagement.types.EnrolledAuthenticationFactorOptions
 import com.workos.usermanagement.types.ListInvitationsOptions
@@ -271,8 +274,34 @@ class UserManagementApi(private val workos: WorkOS) {
   }
 
   /**
+   * Get the details of an existing email verification code.
+   */
+  fun getEmailVerification(id: String): EmailVerification {
+    return workos.get("/user_management/email_verification/$id", EmailVerification::class.java)
+  }
+
+  /**
+   * Get the details of an existing password reset token.
+   */
+  fun getPasswordReset(id: String): PasswordReset {
+    return workos.get("/user_management/password_reset/$id", PasswordReset::class.java)
+  }
+
+  /**
+   * Creates a password reset token that can be used to reset a user's password.
+   */
+  fun createPasswordReset(options: CreatePasswordResetOptions): PasswordReset {
+    return workos.post(
+      "/user_management/password_reset",
+      PasswordReset::class.java,
+      RequestConfig.builder().data(options).build()
+    )
+  }
+
+  /**
    * Send a password reset email and change the user’s password.
    */
+  @Deprecated("Please use `createPasswordReset` instead. This method will be removed in a future major version.")
   fun sendPasswordResetEmail(email: String, passwordResetUrl: String) {
     return workos.post(
       "/user_management/password_reset/send",

--- a/src/main/kotlin/com/workos/usermanagement/builders/CreatePasswordResetOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/CreatePasswordResetOptionsBuilder.kt
@@ -1,0 +1,31 @@
+package com.workos.usermanagement.builders
+
+import com.workos.usermanagement.types.CreatePasswordResetOptions
+
+/**
+ * Builder for options when creating a password reset token.
+ *
+ * @param email The email address of the user.
+ */
+class CreatePasswordResetOptionsBuilder @JvmOverloads constructor(
+  private var email: String,
+) {
+  /**
+   * Generates the CreatePasswordResetOptions object.
+   */
+  fun build(): CreatePasswordResetOptions {
+    return CreatePasswordResetOptions(
+      email = this.email,
+    )
+  }
+
+  /**
+   * @suppress
+   */
+  companion object {
+    @JvmStatic
+    fun create(email: String): CreatePasswordResetOptionsBuilder {
+      return CreatePasswordResetOptionsBuilder(email)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/usermanagement/models/EmailVerification.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/EmailVerification.kt
@@ -1,0 +1,38 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * An email verification code that allows the recipient to verify their email
+ *
+ * @param id The unique ID of the email verification code.
+ * @param userId The unique ID of the user.
+ * @param email The email address of the user.
+ * @param expiresAt The timestamp when the email verification code will expire.
+ * @param code The email verification code.
+ * @param createdAt The timestamp when the email verification code was created.
+ * @param updatedAt The timestamp when the email verification code was last updated.
+ */
+data class EmailVerification @JsonCreator constructor(
+  @JsonProperty("id")
+  val id: String,
+
+  @JsonProperty("user_id")
+  val userId: String,
+
+  @JsonProperty("email")
+  val email: String,
+
+  @JsonProperty("expires_at")
+  val expiresAt: String,
+
+  @JsonProperty("code")
+  val code: String,
+
+  @JsonProperty("created_at")
+  val createdAt: String,
+
+  @JsonProperty("updated_at")
+  val updatedAt: String
+)

--- a/src/main/kotlin/com/workos/usermanagement/models/EmailVerificationEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/EmailVerificationEventData.kt
@@ -1,0 +1,34 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * An email verification code that allows the recipient to verify their email
+ *
+ * @param id The unique ID of the email verification code.
+ * @param userId The unique ID of the user.
+ * @param email The email address of the user.
+ * @param expiresAt The timestamp when the email verification code will expire.
+ * @param createdAt The timestamp when the email verification code was created.
+ * @param updatedAt The timestamp when the email verification code was last updated.
+ */
+data class EmailVerificationEventData @JsonCreator constructor(
+  @JsonProperty("id")
+  val id: String,
+
+  @JsonProperty("user_id")
+  val userId: String,
+
+  @JsonProperty("email")
+  val email: String,
+
+  @JsonProperty("expires_at")
+  val expiresAt: String,
+
+  @JsonProperty("created_at")
+  val createdAt: String,
+
+  @JsonProperty("updated_at")
+  val updatedAt: String
+)

--- a/src/main/kotlin/com/workos/usermanagement/models/Invitation.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/Invitation.kt
@@ -18,6 +18,7 @@ import com.workos.usermanagement.types.InvitationStateEnumType
  * @param token The token of an invitation.
  * @param acceptInvitationUrl The URL where the user can accept the invitation.
  * @param organizationId The ID of the organization.
+ * @param inviterUserId The ID of the user that invited the recipient, if provided.
  * @param createdAt The timestamp when the invitation was created.
  * @param updatedAt The timestamp when the invitation was last updated.
  */
@@ -48,6 +49,9 @@ data class Invitation @JsonCreator constructor(
 
   @JsonProperty("organization_id")
   val organizationId: String? = null,
+
+  @JsonProperty("inviter_user_id")
+  val inviterUserId: String? = null,
 
   @JsonProperty("created_at")
   val createdAt: String,

--- a/src/main/kotlin/com/workos/usermanagement/models/InvitationEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/InvitationEventData.kt
@@ -16,6 +16,7 @@ import com.workos.usermanagement.types.InvitationStateEnumType
  * @param revokedAt The timestamp when the invitation was revoked.
  * @param expiresAt The timestamp when the invitation will expire.
  * @param organizationId The ID of the organization.
+ * @param inviterUserId The ID of the user that invited the recipient, if provided.
  * @param createdAt The timestamp when the invitation was created.
  * @param updatedAt The timestamp when the invitation was last updated.
  */
@@ -40,6 +41,9 @@ data class InvitationEventData @JsonCreator constructor(
 
   @JsonProperty("organization_id")
   val organizationId: String? = null,
+
+  @JsonProperty("inviter_user_id")
+  val inviterUserId: String? = null,
 
   @JsonProperty("created_at")
   val createdAt: String,

--- a/src/main/kotlin/com/workos/usermanagement/models/PasswordReset.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/PasswordReset.kt
@@ -1,0 +1,38 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * A password reset token that allows the recipient to reset their password
+ *
+ * @param id The unique ID of the password reset token.
+ * @param userId The unique ID of the user.
+ * @param email The email address of the user.
+ * @param passwordResetToken The token for password reset.
+ * @param passwordResetUrl The URL where the user can reset their password.
+ * @param expiresAt The timestamp when the password reset token will expire.
+ * @param createdAt The timestamp when the password reset token was created.
+ */
+data class PasswordReset @JsonCreator constructor(
+  @JsonProperty("id")
+  val id: String,
+
+  @JsonProperty("user_id")
+  val userId: String,
+
+  @JsonProperty("email")
+  val email: String,
+
+  @JsonProperty("password_reset_token")
+  val passwordResetToken: String,
+
+  @JsonProperty("password_reset_url")
+  val passwordResetUrl: String,
+
+  @JsonProperty("expires_at")
+  val expiresAt: String,
+
+  @JsonProperty("created_at")
+  val createdAt: String
+)

--- a/src/main/kotlin/com/workos/usermanagement/models/PasswordResetEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/PasswordResetEventData.kt
@@ -1,0 +1,30 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * A password reset token that allows the recipient to reset their password
+ *
+ * @param id The unique ID of the password reset token.
+ * @param userId The unique ID of the user.
+ * @param email The email address of the user.
+ * @param expiresAt The timestamp when the password reset token will expire.
+ * @param createdAt The timestamp when the password reset token was created.
+ */
+data class PasswordResetEventData @JsonCreator constructor(
+  @JsonProperty("id")
+  val id: String,
+
+  @JsonProperty("user_id")
+  val userId: String,
+
+  @JsonProperty("email")
+  val email: String,
+
+  @JsonProperty("expires_at")
+  val expiresAt: String,
+
+  @JsonProperty("created_at")
+  val createdAt: String
+)

--- a/src/main/kotlin/com/workos/usermanagement/types/CreatePasswordResetOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/CreatePasswordResetOptions.kt
@@ -1,0 +1,15 @@
+package com.workos.usermanagement.types
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class CreatePasswordResetOptions(
+  /**
+   * The email address of the user.
+   */
+  @JsonProperty("email")
+  val email: String,
+) {
+  init {
+    require(email.isNotBlank()) { "Email is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/webhooks/models/EmailVerificationEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/EmailVerificationEvent.kt
@@ -1,0 +1,20 @@
+package com.workos.webhooks.models
+
+import com.workos.usermanagement.models.EmailVerificationEventData
+
+/**
+ * Webhook Event for `email_verification.*` events.
+ */
+class EmailVerificationEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: EmailVerificationEventData,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/EventType.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/EventType.kt
@@ -82,6 +82,11 @@ enum class EventType(
   DirectoryGroupDeleted("dsync.group.deleted"),
 
   /**
+   * Triggers when a user is required to verify their email.
+   */
+  EmailVerificationCreated("email_verification.created"),
+
+  /**
    * Triggers when a user is invited to sign up or to join an organization.
    */
   InvitationCreated("invitation.created"),
@@ -104,5 +109,10 @@ enum class EventType(
   /**
    * Triggers when an organization membership is updated.
    */
-  OrganizationMembershipUpdated("organization_membership.updated")
+  OrganizationMembershipUpdated("organization_membership.updated"),
+
+  /**
+   * Triggers when a user requests to reset their password.
+   */
+  PasswordResetCreated("password_reset.created")
 }

--- a/src/main/kotlin/com/workos/webhooks/models/PasswordResetEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/PasswordResetEvent.kt
@@ -1,0 +1,20 @@
+package com.workos.webhooks.models
+
+import com.workos.usermanagement.models.PasswordResetEventData
+
+/**
+ * Webhook Event for `password_reset.*` events.
+ */
+class PasswordResetEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: PasswordResetEventData,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -11,9 +11,11 @@ import com.workos.directorysync.models.Directory
 import com.workos.directorysync.models.Group
 import com.workos.directorysync.models.User
 import com.workos.sso.models.Connection
+import com.workos.usermanagement.models.EmailVerificationEventData
 import com.workos.usermanagement.models.InvitationEventData
 import com.workos.usermanagement.models.MagicAuthEventData
 import com.workos.usermanagement.models.OrganizationMembership
+import com.workos.usermanagement.models.PasswordResetEventData
 
 /**
  * Custom JSON deserializer for [com.workos.webhooks.models.WebhookEvent] events.
@@ -51,11 +53,13 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
       EventType.DirectoryGroupDeleted -> DirectoryGroupDeletedEvent(id, eventType, deserializeData(data, Group::class.java), createdAt)
       EventType.DirectoryGroupUserAdded -> DirectoryGroupUserAddedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), createdAt)
       EventType.DirectoryGroupUserRemoved -> DirectoryGroupUserRemovedEvent(id, eventType, deserializeData(data, DirectoryGroupUserEvent::class.java), createdAt)
+      EventType.EmailVerificationCreated -> EmailVerificationEvent(id, eventType, deserializeData(data, EmailVerificationEventData::class.java), createdAt)
       EventType.InvitationCreated -> InvitationEvent(id, eventType, deserializeData(data, InvitationEventData::class.java), createdAt)
       EventType.MagicAuthCreated -> MagicAuthEvent(id, eventType, deserializeData(data, MagicAuthEventData::class.java), createdAt)
       EventType.OrganizationMembershipCreated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipDeleted -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipUpdated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
+      EventType.PasswordResetCreated -> PasswordResetEvent(id, eventType, deserializeData(data, PasswordResetEventData::class.java), createdAt)
     }
   }
 

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -6,6 +6,7 @@ import com.workos.test.TestBase
 import com.workos.usermanagement.builders.AuthenticationAdditionalOptionsBuilder
 import com.workos.usermanagement.builders.CreateMagicAuthOptionsBuilder
 import com.workos.usermanagement.builders.CreateOrganizationMembershipOptionsBuilder
+import com.workos.usermanagement.builders.CreatePasswordResetOptionsBuilder
 import com.workos.usermanagement.builders.CreateUserOptionsBuilder
 import com.workos.usermanagement.builders.EnrolledAuthenticationFactorOptionsBuilder
 import com.workos.usermanagement.builders.ListInvitationsOptionsBuilder
@@ -16,12 +17,14 @@ import com.workos.usermanagement.builders.UpdateUserOptionsBuilder
 import com.workos.usermanagement.models.AuthenticationChallenge
 import com.workos.usermanagement.models.AuthenticationFactor
 import com.workos.usermanagement.models.AuthenticationTotp
+import com.workos.usermanagement.models.EmailVerification
 import com.workos.usermanagement.models.EnrolledAuthenticationFactor
 import com.workos.usermanagement.models.Identity
 import com.workos.usermanagement.models.Invitation
 import com.workos.usermanagement.models.MagicAuth
 import com.workos.usermanagement.models.OrganizationMembership
 import com.workos.usermanagement.models.OrganizationMembershipRole
+import com.workos.usermanagement.models.PasswordReset
 import com.workos.usermanagement.models.RefreshAuthentication
 import com.workos.usermanagement.models.User
 import com.workos.usermanagement.types.IdentityProviderEnumType
@@ -862,6 +865,104 @@ class UserManagementApiTest : TestBase() {
   }
 
   @Test
+  fun getEmailVerificationShouldReturnValidEmailVerificationObject() {
+    stubResponse(
+      "/user_management/email_verification/email_verification_123",
+      """{
+        "id": "email_verification_123",
+        "user_id": "user_123",
+        "email": "test01@example.com",
+        "expires_at": "2021-07-01T19:07:33.155Z",
+        "code": "123456",
+        "created_at": "2021-06-25T19:07:33.155Z",
+        "updated_at": "2021-06-25T19:07:33.155Z"
+      }"""
+    )
+
+    val emailVerification = workos.userManagement.getEmailVerification("email_verification_123")
+
+    assertEquals(
+      EmailVerification(
+        "email_verification_123",
+        "user_123",
+        "test01@example.com",
+        "2021-07-01T19:07:33.155Z",
+        "123456",
+        "2021-06-25T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z"
+      ),
+      emailVerification
+    )
+  }
+
+  @Test
+  fun getPasswordResetShouldReturnValidPasswordResetObject() {
+    stubResponse(
+      "/user_management/password_reset/password_reset_123",
+      """{
+        "id": "password_reset_123",
+        "user_id": "user_123",
+        "email": "test01@example.com",
+        "password_reset_token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "password_reset_url": "https://your-app.com/reset-password?token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "expires_at": "2021-07-01T19:07:33.155Z",
+        "created_at": "2021-06-25T19:07:33.155Z"
+      }"""
+    )
+
+    val passwordReset = workos.userManagement.getPasswordReset("password_reset_123")
+
+    assertEquals(
+      PasswordReset(
+        "password_reset_123",
+        "user_123",
+        "test01@example.com",
+        "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://your-app.com/reset-password?token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "2021-07-01T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z"
+      ),
+      passwordReset
+    )
+  }
+
+  @Test
+  fun createPasswordResetShouldReturnValidPasswordResetObject() {
+    stubResponse(
+      "/user_management/password_reset",
+      """{
+        "id": "password_reset_123",
+        "user_id": "user_123",
+        "email": "test01@example.com",
+        "password_reset_token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "password_reset_url": "https://your-app.com/reset-password?token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "expires_at": "2021-07-01T19:07:33.155Z",
+        "created_at": "2021-06-25T19:07:33.155Z"
+      }""",
+      requestBody = """{
+        "email": "test01@example.com"
+      }"""
+    )
+
+    val options = CreatePasswordResetOptionsBuilder("test01@example.com").build()
+
+    val passwordReset = workos.userManagement.createPasswordReset(options)
+
+    assertEquals(
+      PasswordReset(
+        "password_reset_123",
+        "user_123",
+        "test01@example.com",
+        "Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://your-app.com/reset-password?token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "2021-07-01T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z"
+      ),
+      passwordReset
+    )
+  }
+
+  @Test
   fun sendPasswordResetEmailShouldWorkAndReturnNothing() {
     stubResponse("/user_management/password_reset/send", "")
 
@@ -1223,8 +1324,9 @@ class UserManagementApiTest : TestBase() {
         "revoked_at": null,
         "expires_at": "2021-07-01T19:07:33.155Z",
         "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
-        "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "accept_invitation_url": "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "organization_id": "org_456",
+        "inviter_user_id": "user_789",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }"""
@@ -1241,8 +1343,9 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-07-01T19:07:33.155Z",
         "Z1uX3RbwcIl5fIGJJJCXXisdI",
-        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
+        "user_789",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),
@@ -1264,8 +1367,9 @@ class UserManagementApiTest : TestBase() {
             "revoked_at": null,
             "expires_at": "2021-07-01T19:07:33.155Z",
             "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
-            "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "accept_invitation_url": "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
             "organization_id": "org_456",
+            "inviter_user_id": "user_789",
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:07:33.155Z"
           }
@@ -1288,8 +1392,9 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-07-01T19:07:33.155Z",
         "Z1uX3RbwcIl5fIGJJJCXXisdI",
-        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
+        "user_789",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),
@@ -1317,8 +1422,9 @@ class UserManagementApiTest : TestBase() {
             "revoked_at": null,
             "expires_at": "2021-07-01T19:07:33.155Z",
             "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
-            "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+            "accept_invitation_url": "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
             "organization_id": "org_456",
+            "inviter_user_id": "user_789",
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:07:33.155Z"
           }
@@ -1350,8 +1456,9 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-07-01T19:07:33.155Z",
         "Z1uX3RbwcIl5fIGJJJCXXisdI",
-        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
+        "user_789",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),
@@ -1377,7 +1484,8 @@ class UserManagementApiTest : TestBase() {
         "revoked_at": null,
         "expires_at": "2021-07-01T19:07:33.155Z",
         "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
-        "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "accept_invitation_url": "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "inviter_user_id": "user_789",
         "organization_id": "org_456",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
@@ -1409,8 +1517,9 @@ class UserManagementApiTest : TestBase() {
         null,
         "2021-07-01T19:07:33.155Z",
         "Z1uX3RbwcIl5fIGJJJCXXisdI",
-        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
+        "user_789",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),
@@ -1430,7 +1539,8 @@ class UserManagementApiTest : TestBase() {
         "revoked_at": "2021-08-01T19:07:33.155Z",
         "expires_at": "2021-07-01T19:07:33.155Z",
         "token": "Z1uX3RbwcIl5fIGJJJCXXisdI",
-        "accept_invitation_url": "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "accept_invitation_url": "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "inviter_user_id": "user_789",
         "organization_id": "org_456",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
@@ -1448,8 +1558,9 @@ class UserManagementApiTest : TestBase() {
         "2021-08-01T19:07:33.155Z",
         "2021-07-01T19:07:33.155Z",
         "Z1uX3RbwcIl5fIGJJJCXXisdI",
-        "https://myauthkit.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
+        "https://your-app.com/invite?invitation_token=Z1uX3RbwcIl5fIGJJJCXXisdI",
         "org_456",
+        "user_789",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),

--- a/src/test/kotlin/com/workos/test/webhooks/EmailVerificationWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/EmailVerificationWebhookTests.kt
@@ -1,0 +1,50 @@
+package com.workos.test.webhooks
+
+import com.workos.test.TestBase
+import com.workos.webhooks.models.EmailVerificationEvent
+import com.workos.webhooks.models.EventType
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import kotlin.test.assertEquals
+
+class EmailVerificationWebhookTests : TestBase() {
+
+  private val emailVerificationId = "email_verification_01EHWNC0FCBHZ3BJ7EGKYXK0E7"
+  private val webhookId = "wh_01FMXJ2W7T9VY7EAHHMBF2K07Y"
+
+  private fun generateWebhookEvent(eventType: EventType): String {
+    return """
+    {
+      "id": "$webhookId",
+      "event": "${eventType.value}",
+      "data": {
+        "object": "email_verification",
+        "id": "$emailVerificationId",
+        "user_id": "user_01HWZBQAY251RZ9BKB4RZW4D4A",
+        "email": "marcelina@foo-corp.com",
+        "expires_at": "2023-11-27T19:07:33.155Z",
+        "created_at": "2023-11-27T19:07:33.155Z",
+        "updated_at": "2023-11-27T19:07:33.155Z"
+      },
+      "created_at": "2023-11-27T19:07:33.155Z"
+    }
+    """
+  }
+
+  @Test
+  fun constructEmailVerificationCreatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.EmailVerificationCreated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is EmailVerificationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as EmailVerificationEvent).data.id, emailVerificationId)
+  }
+}

--- a/src/test/kotlin/com/workos/test/webhooks/PasswordResetWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/PasswordResetWebhookTests.kt
@@ -1,0 +1,49 @@
+package com.workos.test.webhooks
+
+import com.workos.test.TestBase
+import com.workos.webhooks.models.EventType
+import com.workos.webhooks.models.PasswordResetEvent
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import kotlin.test.assertEquals
+
+class PasswordResetWebhookTests : TestBase() {
+
+  private val passwordResetId = "password_reset_01EHWNC0FCBHZ3BJ7EGKYXK0E7"
+  private val webhookId = "wh_01FMXJ2W7T9VY7EAHHMBF2K07Y"
+
+  private fun generateWebhookEvent(eventType: EventType): String {
+    return """
+    {
+      "id": "$webhookId",
+      "event": "${eventType.value}",
+      "data": {
+        "object": "password_reset",
+        "id": "$passwordResetId",
+        "user_id": "user_01HWZBQAY251RZ9BKB4RZW4D4A",
+        "email": "marcelina@foo-corp.com",
+        "expires_at": "2023-11-27T19:07:33.155Z",
+        "created_at": "2023-11-27T19:07:33.155Z"
+      },
+      "created_at": "2023-11-27T19:07:33.155Z"
+    }
+    """
+  }
+
+  @Test
+  fun constructPasswordResetCreatedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.PasswordResetCreated)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is PasswordResetEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as PasswordResetEvent).data.id, passwordResetId)
+  }
+}


### PR DESCRIPTION
## Description

- Add `inviterUserId` to invitation object
- Add `email_verification.created` and `password_reset.created` events
- Add `GET /user_management/email_verification/:id` endpoint
- Add `GET /user_management/password_reset/:id` and `POST /user_management/password_reset` endpoints
- Deprecate current send password reset endpoint

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

https://github.com/workos/workos/pull/27414