### PR TITLE
Add AppleOAuth to comments

### DIFF
--- a/src/main/kotlin/com/workos/sso/SsoApi.kt
+++ b/src/main/kotlin/com/workos/sso/SsoApi.kt
@@ -25,7 +25,7 @@ class SsoApi(private val workos: WorkOS) {
    * @param redirectUri A redirect URI to return an authorized user to.
    * @param connection Connection ID to determine which identity provider to authenticate with.
    * @param domain Use the domain to determine which connection and identity provider to authenticate with.
-   * @param provider Name of the identity provider e.g. GitHubOAuth, GoogleOAuth, or MicrosoftOAuth.
+   * @param provider Name of the identity provider e.g. AppleOAuth, GitHubOAuth, GoogleOAuth, or MicrosoftOAuth.
    * @param state User defined information to persist application data between redirects.
    */
   class AuthorizationUrlOptionsBuilder @JvmOverloads constructor(
@@ -77,10 +77,10 @@ class SsoApi(private val workos: WorkOS) {
     /**
      * Value used to authenticate all users with the same connection and Identity Provider.
      *
-     * Currently, the only supported values for provider are GitHubOAuth, GoogleOAuth, and
-     * MicrosoftOAuth. Provide the provider parameter when authenticating Google OAuth
-     * users, because Google OAuth does not take a user’s domain into account when logging
-     * in with a “Sign in with Google” button.
+     * Currently, the only supported values for provider are AppleOAuth, GitHubOAuth,
+     * GoogleOAuth, and MicrosoftOAuth. Provide the provider parameter when authenticating
+     * Google OAuth users, because Google OAuth does not take a user’s domain into account
+     * when logging in with a “Sign in with Google” button.
      */
     fun provider(value: String) = apply { provider = value }
 


### PR DESCRIPTION
## Description
This one is a comment-only update.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
