### PR TITLE
Deprecate `allowProfilesOutsideOrganization` option

### DIFF
--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -57,6 +57,7 @@ class OrganizationsApi(private val workos: WorkOS) {
       /**
        * Sets whether profiles with unmatched domains can exist within the organization.
        */
+      @Deprecated("If you need to allow sign-ins from any email domain, contact support@workos.com.")
       fun allowProfilesOutsideOrganization(value: Boolean) = apply { allowProfilesOutsideOrganization = value }
 
       /**
@@ -252,6 +253,7 @@ class OrganizationsApi(private val workos: WorkOS) {
       /**
        * Sets whether profiles with unmatched domains can exist within the organization.
        */
+      @Deprecated("If you need to allow sign-ins from any email domain, contact support@workos.com.")
       fun allowProfilesOutsideOrganization(value: Boolean) = apply { allowProfilesOutsideOrganization = value }
 
       /**


### PR DESCRIPTION
## Description

Deprecates the `allowProfilesOutsideOrganization` option on the builders for the create and update Organization methods.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
