### PR TITLE
Fix list endpoints

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -40,6 +40,8 @@ dependencies {
 
   implementation("com.github.kittinunf.fuel:fuel:2.3.1")
 
+  implementation("org.jetbrains.kotlin:kotlin-reflect:1.5.0")
+
   testImplementation("org.jetbrains.kotlin:kotlin-test")
 
   testImplementation("org.jetbrains.kotlin:kotlin-test-junit")

--- a/src/main/kotlin/com/workos/common/http/RequestConfig.kt
+++ b/src/main/kotlin/com/workos/common/http/RequestConfig.kt
@@ -32,7 +32,7 @@ class RequestConfig(
                   if (value::class.isData) {
                     toMap(value)
                   } else {
-                    value
+                    value.toString()
                   }
                 }
           }

--- a/src/main/kotlin/com/workos/common/http/RequestConfig.kt
+++ b/src/main/kotlin/com/workos/common/http/RequestConfig.kt
@@ -1,5 +1,9 @@
 package com.workos.common.http
 
+import kotlin.reflect.KClass
+import kotlin.reflect.KProperty1
+import kotlin.reflect.full.memberProperties
+
 /**
  * Configuration for HTTP Requests.
  *
@@ -8,23 +12,41 @@ package com.workos.common.http
  * @param data The body of the request.
  */
 class RequestConfig(
-  val params: Map<String, String>? = null,
-  val headers: Map<String, String>? = null,
-  val data: Any? = null
+    val params: Map<String, String>? = null,
+    val headers: Map<String, String>? = null,
+    val data: Any? = null
 ) {
-  /**
-   * @suppress
-   */
+  /** @suppress */
   companion object {
     @JvmStatic
     fun builder(): RequestConfigBuilder {
       return RequestConfigBuilder()
     }
+
+    /** Helper method for converting data into params. */
+    infix fun <T : Any> toMap(obj: T): Map<String, Any?> {
+      val params =
+          (obj::class as KClass<T>).memberProperties.associate { prop: KProperty1<T, *> ->
+            prop.name.toSnakeCase() to
+                prop.get(obj)?.let { value ->
+                  if (value::class.isData) {
+                    toMap(value)
+                  } else {
+                    value
+                  }
+                }
+          }
+
+      return params.filterValues { it != null }
+    }
+
+    /** Convert camel case to snake case. */
+    fun String.toSnakeCase() = replace(humps, "_").lowercase()
+
+    private val humps = "(?<=.)(?=\\p{Upper})".toRegex()
   }
 
-  /**
-   * Builder class for creating [RequestConfig].
-   */
+  /** Builder class for creating [RequestConfig]. */
   class RequestConfigBuilder {
     private var params: Map<String, String> = emptyMap()
 
@@ -32,24 +54,16 @@ class RequestConfig(
 
     private var data: Any? = null
 
-    /**
-     * Set the request parameters.
-     */
+    /** Set the request parameters. */
     fun params(value: Map<String, String>) = apply { params = value }
 
-    /**
-     * Set the request headers.
-     */
+    /** Set the request headers. */
     fun headers(value: Map<String, String?>) = apply { headers = value as Map<String, String> }
 
-    /**
-     * Set the request body.
-     */
+    /** Set the request body. */
     fun data(value: Any) = apply { data = value }
 
-    /**
-     * Creates an instance of [RequestConfig] with the given params.
-     */
+    /** Creates an instance of [RequestConfig] with the given params. */
     fun build(): RequestConfig {
       return RequestConfig(params, headers, data)
     }

--- a/src/main/kotlin/com/workos/common/http/RequestConfig.kt
+++ b/src/main/kotlin/com/workos/common/http/RequestConfig.kt
@@ -12,9 +12,9 @@ import kotlin.reflect.full.memberProperties
  * @param data The body of the request.
  */
 class RequestConfig(
-    val params: Map<String, String>? = null,
-    val headers: Map<String, String>? = null,
-    val data: Any? = null
+  val params: Map<String, String>? = null,
+  val headers: Map<String, String>? = null,
+  val data: Any? = null
 ) {
   /** @suppress */
   companion object {
@@ -26,16 +26,16 @@ class RequestConfig(
     /** Helper method for converting data into params. */
     infix fun <T : Any> toMap(obj: T): Map<String, Any?> {
       val params =
-          (obj::class as KClass<T>).memberProperties.associate { prop: KProperty1<T, *> ->
-            prop.name.toSnakeCase() to
-                prop.get(obj)?.let { value ->
-                  if (value::class.isData) {
-                    toMap(value)
-                  } else {
-                    value.toString()
-                  }
-                }
-          }
+        (obj::class as KClass<T>).memberProperties.associate { prop: KProperty1<T, *> ->
+          prop.name.toSnakeCase() to
+            prop.get(obj)?.let { value ->
+              if (value::class.isData) {
+                toMap(value)
+              } else {
+                value.toString()
+              }
+            }
+        }
 
       return params.filterValues { it != null }
     }

--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -50,30 +50,30 @@ class UserManagementApi(private val workos: WorkOS) {
   /** Get a list of all the existing users matching the criteria specified. */
   fun listUsers(options: ListUsersOptions? = null): Users {
     val params: Map<String, String> =
-        RequestConfig.toMap(options ?: ListUsersOptions()) as Map<String, String>
+      RequestConfig.toMap(options ?: ListUsersOptions()) as Map<String, String>
 
     return workos.get(
-        "/user_management/users",
-        Users::class.java,
-        RequestConfig.builder().params(params).build()
+      "/user_management/users",
+      Users::class.java,
+      RequestConfig.builder().params(params).build()
     )
   }
 
   /** Create a new user in the current environment. */
   fun createUser(options: CreateUserOptions): User {
     return workos.post(
-        "/user_management/users",
-        User::class.java,
-        RequestConfig.builder().data(options).build()
+      "/user_management/users",
+      User::class.java,
+      RequestConfig.builder().data(options).build()
     )
   }
 
   /** Updates properties of a user. The omitted properties will be left unchanged. */
   fun updateUser(userId: String, options: UpdateUserOptions): User {
     return workos.put(
-        "/user_management/users/$userId",
-        User::class.java,
-        RequestConfig.builder().data(options).build()
+      "/user_management/users/$userId",
+      User::class.java,
+      RequestConfig.builder().data(options).build()
     )
   }
 
@@ -97,69 +97,69 @@ class UserManagementApi(private val workos: WorkOS) {
 
   /** Authenticates a user using AuthKit, OAuth or an organization’s SSO connection. */
   fun authenticateWithCode(
-      clientId: String,
-      code: String,
-      options: AuthenticationAdditionalOptions? = null
+    clientId: String,
+    code: String,
+    options: AuthenticationAdditionalOptions? = null
   ): Authentication {
     return workos.post(
-        "/user_management/authenticate",
-        Authentication::class.java,
-        RequestConfig.builder()
-            .data(
-                AuthenticationWithCodeOptionsBuilder.create(clientId, workos.apiKey, code, options)
-                    .build()
-            )
+      "/user_management/authenticate",
+      Authentication::class.java,
+      RequestConfig.builder()
+        .data(
+          AuthenticationWithCodeOptionsBuilder.create(clientId, workos.apiKey, code, options)
             .build()
+        )
+        .build()
     )
   }
 
   /** Authenticates a user with email and password. */
   fun authenticateWithPassword(
-      clientId: String,
-      email: String,
-      password: String,
-      options: AuthenticationAdditionalOptions? = null
+    clientId: String,
+    email: String,
+    password: String,
+    options: AuthenticationAdditionalOptions? = null
   ): Authentication {
     return workos.post(
-        "/user_management/authenticate",
-        Authentication::class.java,
-        RequestConfig.builder()
-            .data(
-                AuthenticationWithPasswordOptionsBuilder.create(
-                        clientId,
-                        workos.apiKey,
-                        email,
-                        password,
-                        options
-                    )
-                    .build()
-            )
+      "/user_management/authenticate",
+      Authentication::class.java,
+      RequestConfig.builder()
+        .data(
+          AuthenticationWithPasswordOptionsBuilder.create(
+            clientId,
+            workos.apiKey,
+            email,
+            password,
+            options
+          )
             .build()
+        )
+        .build()
     )
   }
 
   /** Authenticates a user by verifying the Magic Auth code sent to the user’s email. */
   fun authenticateWithMagicAuth(
-      clientId: String,
-      email: String,
-      code: String,
-      options: AuthenticationAdditionalOptions? = null
+    clientId: String,
+    email: String,
+    code: String,
+    options: AuthenticationAdditionalOptions? = null
   ): Authentication {
     return workos.post(
-        "/user_management/authenticate",
-        Authentication::class.java,
-        RequestConfig.builder()
-            .data(
-                AuthenticationWithMagicAuthOptionsBuilder.create(
-                        clientId,
-                        workos.apiKey,
-                        email,
-                        code,
-                        options
-                    )
-                    .build()
-            )
+      "/user_management/authenticate",
+      Authentication::class.java,
+      RequestConfig.builder()
+        .data(
+          AuthenticationWithMagicAuthOptionsBuilder.create(
+            clientId,
+            workos.apiKey,
+            email,
+            code,
+            options
+          )
             .build()
+        )
+        .build()
     )
   }
 
@@ -168,101 +168,101 @@ class UserManagementApi(private val workos: WorkOS) {
    * use, so a new refresh token is returned.
    */
   fun authenticateWithRefreshToken(
-      clientId: String,
-      refreshToken: String,
-      options: AuthenticationAdditionalOptions? = null
+    clientId: String,
+    refreshToken: String,
+    options: AuthenticationAdditionalOptions? = null
   ): RefreshAuthentication {
     return workos.post(
-        "/user_management/authenticate",
-        RefreshAuthentication::class.java,
-        RequestConfig.builder()
-            .data(
-                AuthenticationWithRefreshTokenOptionsBuilder.create(
-                        clientId,
-                        workos.apiKey,
-                        refreshToken,
-                        options
-                    )
-                    .build()
-            )
+      "/user_management/authenticate",
+      RefreshAuthentication::class.java,
+      RequestConfig.builder()
+        .data(
+          AuthenticationWithRefreshTokenOptionsBuilder.create(
+            clientId,
+            workos.apiKey,
+            refreshToken,
+            options
+          )
             .build()
+        )
+        .build()
     )
   }
 
   /** Authenticates a user with an unverified email and verifies their email address. */
   fun authenticateWithEmailVerification(
-      clientId: String,
-      code: String,
-      pendingAuthenticationToken: String,
-      options: AuthenticationAdditionalOptions? = null
+    clientId: String,
+    code: String,
+    pendingAuthenticationToken: String,
+    options: AuthenticationAdditionalOptions? = null
   ): Authentication {
     return workos.post(
-        "/user_management/authenticate",
-        Authentication::class.java,
-        RequestConfig.builder()
-            .data(
-                AuthenticationWithEmailVerificationOptionsBuilder.create(
-                        clientId,
-                        workos.apiKey,
-                        code,
-                        pendingAuthenticationToken,
-                        options
-                    )
-                    .build()
-            )
+      "/user_management/authenticate",
+      Authentication::class.java,
+      RequestConfig.builder()
+        .data(
+          AuthenticationWithEmailVerificationOptionsBuilder.create(
+            clientId,
+            workos.apiKey,
+            code,
+            pendingAuthenticationToken,
+            options
+          )
             .build()
+        )
+        .build()
     )
   }
 
   /** Authenticates a user enrolled into MFA using time-based one-time password (TOTP). */
   fun authenticateWithTotp(
-      clientId: String,
-      code: String,
-      authenticationChallengeId: String,
-      pendingAuthenticationToken: String,
-      options: AuthenticationAdditionalOptions? = null
+    clientId: String,
+    code: String,
+    authenticationChallengeId: String,
+    pendingAuthenticationToken: String,
+    options: AuthenticationAdditionalOptions? = null
   ): Authentication {
     return workos.post(
-        "/user_management/authenticate",
-        Authentication::class.java,
-        RequestConfig.builder()
-            .data(
-                AuthenticationWithTotpOptionsBuilder.create(
-                        clientId,
-                        workos.apiKey,
-                        code,
-                        authenticationChallengeId,
-                        pendingAuthenticationToken,
-                        options
-                    )
-                    .build()
-            )
+      "/user_management/authenticate",
+      Authentication::class.java,
+      RequestConfig.builder()
+        .data(
+          AuthenticationWithTotpOptionsBuilder.create(
+            clientId,
+            workos.apiKey,
+            code,
+            authenticationChallengeId,
+            pendingAuthenticationToken,
+            options
+          )
             .build()
+        )
+        .build()
     )
   }
 
   /** Authenticates a user into an organization they are a member of. */
   fun authenticateWithOrganizationSelection(
-      clientId: String,
-      organizationId: String,
-      pendingAuthenticationToken: String,
-      options: AuthenticationAdditionalOptions? = null
+    clientId: String,
+    organizationId: String,
+    pendingAuthenticationToken: String,
+    options: AuthenticationAdditionalOptions? = null
   ): Authentication {
     return workos.post(
-        "/user_management/authenticate",
-        Authentication::class.java,
-        RequestConfig.builder()
-            .data(
-                AuthenticationWithOrganizationSelectionOptionsBuilder.create(
-                        clientId,
-                        workos.apiKey,
-                        organizationId,
-                        pendingAuthenticationToken,
-                        options
-                    )
-                    .build()
-            )
+      "/user_management/authenticate",
+      Authentication::class.java,
+      RequestConfig.builder()
+        .data(
+          AuthenticationWithOrganizationSelectionOptionsBuilder.create(
+            clientId,
+            workos.apiKey,
+            organizationId,
+            pendingAuthenticationToken,
+            options
+          )
             .build()
+        )
+        .build()
     )
   }
 
@@ -279,9 +279,9 @@ class UserManagementApi(private val workos: WorkOS) {
   /** Creates a Magic Auth code that can be used to authenticate into your app. */
   fun createMagicAuth(options: CreateMagicAuthOptions): MagicAuth {
     return workos.post(
-        "/user_management/magic_auth",
-        MagicAuth::class.java,
-        RequestConfig.builder().data(options).build()
+      "/user_management/magic_auth",
+      MagicAuth::class.java,
+      RequestConfig.builder().data(options).build()
     )
   }
 
@@ -290,32 +290,32 @@ class UserManagementApi(private val workos: WorkOS) {
    * minutes. To verify the code, authenticate the user with Magic Auth.
    */
   @Deprecated(
-      "Please use `createMagicAuth` instead. This method will be removed in a future major version."
+    "Please use `createMagicAuth` instead. This method will be removed in a future major version."
   )
   fun sendMagicAuthCode(email: String) {
     workos.post(
-        "/user_management/magic_auth/send",
-        RequestConfig.builder().data(SendMagicAuthCodeOptionsBuilder.create(email).build()).build()
+      "/user_management/magic_auth/send",
+      RequestConfig.builder().data(SendMagicAuthCodeOptionsBuilder.create(email).build()).build()
     )
   }
 
   /** Enrolls a user in a new authentication factor. */
   fun enrollAuthFactor(
-      id: String,
-      options: EnrolledAuthenticationFactorOptions? = null
+    id: String,
+    options: EnrolledAuthenticationFactorOptions? = null
   ): EnrolledAuthenticationFactor {
     return workos.post(
-        "/user_management/users/$id/auth_factors",
-        EnrolledAuthenticationFactor::class.java,
-        RequestConfig.builder().data(options ?: EnrolledAuthenticationFactorOptions()).build()
+      "/user_management/users/$id/auth_factors",
+      EnrolledAuthenticationFactor::class.java,
+      RequestConfig.builder().data(options ?: EnrolledAuthenticationFactorOptions()).build()
     )
   }
 
   /** Get a list of all authentication factors of a given user. */
   fun listAuthFactors(id: String): AuthenticationFactors {
     return workos.get(
-        "/user_management/users/$id/auth_factors",
-        AuthenticationFactors::class.java,
+      "/user_management/users/$id/auth_factors",
+      AuthenticationFactors::class.java,
     )
   }
 
@@ -332,77 +332,77 @@ class UserManagementApi(private val workos: WorkOS) {
   /** Creates a password reset token that can be used to reset a user's password. */
   fun createPasswordReset(options: CreatePasswordResetOptions): PasswordReset {
     return workos.post(
-        "/user_management/password_reset",
-        PasswordReset::class.java,
-        RequestConfig.builder().data(options).build()
+      "/user_management/password_reset",
+      PasswordReset::class.java,
+      RequestConfig.builder().data(options).build()
     )
   }
 
   /** Send a password reset email and change the user’s password. */
   @Deprecated(
-      "Please use `createPasswordReset` instead. This method will be removed in a future major version."
+    "Please use `createPasswordReset` instead. This method will be removed in a future major version."
   )
   fun sendPasswordResetEmail(email: String, passwordResetUrl: String) {
     return workos.post(
-        "/user_management/password_reset/send",
-        RequestConfig.builder()
-            .data(SendPasswordResetEmailOptionsBuilder.create(email, passwordResetUrl).build())
-            .build()
+      "/user_management/password_reset/send",
+      RequestConfig.builder()
+        .data(SendPasswordResetEmailOptionsBuilder.create(email, passwordResetUrl).build())
+        .build()
     )
   }
 
   /** Sets a new password using the `token` query parameter from the link that the user received. */
   fun resetPassword(token: String, newPassword: String): User {
     return workos.post(
-        "/user_management/password_reset/confirm",
-        User::class.java,
-        RequestConfig.builder()
-            .data(ResetPasswordOptionsBuilder.create(token, newPassword).build())
-            .build()
+      "/user_management/password_reset/confirm",
+      User::class.java,
+      RequestConfig.builder()
+        .data(ResetPasswordOptionsBuilder.create(token, newPassword).build())
+        .build()
     )
   }
 
   /** Get the details of an existing organization membership. */
   fun getOrganizationMembership(id: String): OrganizationMembership {
     return workos.get(
-        "/user_management/organization_memberships/$id",
-        OrganizationMembership::class.java
+      "/user_management/organization_memberships/$id",
+      OrganizationMembership::class.java
     )
   }
 
   /** Get a list of all organization memberships matching the criteria specified. */
   fun listOrganizationMemberships(
-      options: ListOrganizationMembershipsOptions? = null
+    options: ListOrganizationMembershipsOptions? = null
   ): OrganizationMemberships {
     val params: Map<String, String> =
-        RequestConfig.toMap(options ?: ListOrganizationMembershipsOptions()) as Map<String, String>
+      RequestConfig.toMap(options ?: ListOrganizationMembershipsOptions()) as Map<String, String>
 
     return workos.get(
-        "/user_management/organization_memberships",
-        OrganizationMemberships::class.java,
-        RequestConfig.builder().params(params).build()
+      "/user_management/organization_memberships",
+      OrganizationMemberships::class.java,
+      RequestConfig.builder().params(params).build()
     )
   }
 
   /** Creates a new organization membership for the given organization and user. */
   fun createOrganizationMembership(
-      options: CreateOrganizationMembershipOptions
+    options: CreateOrganizationMembershipOptions
   ): OrganizationMembership {
     return workos.post(
-        "/user_management/organization_memberships",
-        OrganizationMembership::class.java,
-        RequestConfig.builder().data(options).build()
+      "/user_management/organization_memberships",
+      OrganizationMembership::class.java,
+      RequestConfig.builder().data(options).build()
     )
   }
 
   /** Update the details of an existing organization membership. */
   fun updateOrganizationMembership(id: String, roleSlug: String): OrganizationMembership {
     return workos.put(
-        "/user_management/organization_memberships/$id",
-        OrganizationMembership::class.java,
-        RequestConfig.builder()
-            .data(UpdateOrganizationMembershipOptionsBuilder.create(id, roleSlug).build())
-            .build()
+      "/user_management/organization_memberships/$id",
+      OrganizationMembership::class.java,
+      RequestConfig.builder()
+        .data(UpdateOrganizationMembershipOptionsBuilder.create(id, roleSlug).build())
+        .build()
     )
   }
 
@@ -414,16 +414,16 @@ class UserManagementApi(private val workos: WorkOS) {
   /** Deactivate an organization membership. */
   fun deactivateOrganizationMembership(id: String): OrganizationMembership {
     return workos.put(
-        "/user_management/organization_memberships/$id/deactivate",
-        OrganizationMembership::class.java
+      "/user_management/organization_memberships/$id/deactivate",
+      OrganizationMembership::class.java
     )
   }
 
   /** Reactivate an organization membership. */
   fun reactivateOrganizationMembership(id: String): OrganizationMembership {
     return workos.put(
-        "/user_management/organization_memberships/$id/reactivate",
-        OrganizationMembership::class.java
+      "/user_management/organization_memberships/$id/reactivate",
+      OrganizationMembership::class.java
     )
   }
 
@@ -440,21 +440,21 @@ class UserManagementApi(private val workos: WorkOS) {
   /** Get a list of all the existing invitations matching the criteria specified. */
   fun listInvitations(options: ListInvitationsOptions? = null): Invitations {
     val params: Map<String, String> =
-        RequestConfig.toMap(options ?: ListInvitationsOptions()) as Map<String, String>
+      RequestConfig.toMap(options ?: ListInvitationsOptions()) as Map<String, String>
 
     return workos.get(
-        "/user_management/invitations",
-        Invitations::class.java,
-        RequestConfig.builder().params(params).build()
+      "/user_management/invitations",
+      Invitations::class.java,
+      RequestConfig.builder().params(params).build()
     )
   }
 
   /** Sends an invitation email to the recipient. */
   fun sendInvitation(options: SendInvitationOptions): Invitation {
     return workos.post(
-        "/user_management/invitations",
-        Invitation::class.java,
-        RequestConfig.builder().data(options).build()
+      "/user_management/invitations",
+      Invitation::class.java,
+      RequestConfig.builder().data(options).build()
     )
   }
 
@@ -466,8 +466,8 @@ class UserManagementApi(private val workos: WorkOS) {
   /** End a user's session. The user's browser should be redirected to this URL. */
   fun getLogoutUrl(sessionId: String): String {
     return URIBuilder(workos.baseUrl)
-        .setPath("/user_management/sessions/logout")
-        .addParameter("session_id", sessionId)
-        .toString()
+      .setPath("/user_management/sessions/logout")
+      .addParameter("session_id", sessionId)
+      .toString()
   }
 }

--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -42,407 +42,432 @@ import com.workos.usermanagement.types.UpdateUserOptions
 import org.apache.http.client.utils.URIBuilder
 
 class UserManagementApi(private val workos: WorkOS) {
-  /**
-   * Get the details of an existing user.
-   */
+  /** Get the details of an existing user. */
   fun getUser(userId: String): User {
     return workos.get("/user_management/users/$userId", User::class.java)
   }
 
-  /**
-   * Get a list of all the existing users matching the criteria specified.
-   */
+  /** Get a list of all the existing users matching the criteria specified. */
   fun listUsers(options: ListUsersOptions? = null): Users {
+    val params: Map<String, String> =
+        RequestConfig.toMap(options ?: ListUsersOptions()) as Map<String, String>
+
     return workos.get(
-      "/user_management/users",
-      Users::class.java,
-      RequestConfig.builder().data(options ?: ListUsersOptions()).build()
+        "/user_management/users",
+        Users::class.java,
+        RequestConfig.builder().params(params).build()
     )
   }
 
-  /**
-   * Create a new user in the current environment.
-   */
+  /** Create a new user in the current environment. */
   fun createUser(options: CreateUserOptions): User {
     return workos.post(
-      "/user_management/users",
-      User::class.java,
-      RequestConfig.builder().data(options).build()
+        "/user_management/users",
+        User::class.java,
+        RequestConfig.builder().data(options).build()
     )
   }
 
-  /**
-   * Updates properties of a user. The omitted properties will be left unchanged.
-   */
+  /** Updates properties of a user. The omitted properties will be left unchanged. */
   fun updateUser(userId: String, options: UpdateUserOptions): User {
     return workos.put(
-      "/user_management/users/$userId",
-      User::class.java,
-      RequestConfig.builder().data(options).build()
+        "/user_management/users/$userId",
+        User::class.java,
+        RequestConfig.builder().data(options).build()
     )
   }
 
-  /**
-   * Deletes a user in the current environment.
-   */
+  /** Deletes a user in the current environment. */
   fun deleteUser(userId: String) {
     workos.delete("/user_management/users/$userId")
   }
 
-  /**
-   * Get the identities associated with the user.
-   */
+  /** Get the identities associated with the user. */
   fun getUserIdentities(userId: String): Array<Identity> {
     return workos.get("/user_management/users/$userId/identities", Array<Identity>::class.java)
   }
 
   /**
-   * Generate an Oauth2 authorization URL where users will
-   * authenticate using the configured SSO Identity Provider.
+   * Generate an Oauth2 authorization URL where users will authenticate using the configured SSO
+   * Identity Provider.
    */
   fun getAuthorizationUrl(clientId: String, redirectUri: String): AuthorizationUrlOptionsBuilder {
     return AuthorizationUrlOptionsBuilder.create(workos.baseUrl, clientId, redirectUri)
   }
 
-  /**
-   * Authenticates a user using AuthKit, OAuth or an organization’s SSO connection.
-   */
-  fun authenticateWithCode(clientId: String, code: String, options: AuthenticationAdditionalOptions? = null): Authentication {
+  /** Authenticates a user using AuthKit, OAuth or an organization’s SSO connection. */
+  fun authenticateWithCode(
+      clientId: String,
+      code: String,
+      options: AuthenticationAdditionalOptions? = null
+  ): Authentication {
     return workos.post(
-      "/user_management/authenticate",
-      Authentication::class.java,
-      RequestConfig.builder().data(
-        AuthenticationWithCodeOptionsBuilder.create(
-          clientId, workos.apiKey, code, options
-        ).build()
-      ).build()
+        "/user_management/authenticate",
+        Authentication::class.java,
+        RequestConfig.builder()
+            .data(
+                AuthenticationWithCodeOptionsBuilder.create(clientId, workos.apiKey, code, options)
+                    .build()
+            )
+            .build()
+    )
+  }
+
+  /** Authenticates a user with email and password. */
+  fun authenticateWithPassword(
+      clientId: String,
+      email: String,
+      password: String,
+      options: AuthenticationAdditionalOptions? = null
+  ): Authentication {
+    return workos.post(
+        "/user_management/authenticate",
+        Authentication::class.java,
+        RequestConfig.builder()
+            .data(
+                AuthenticationWithPasswordOptionsBuilder.create(
+                        clientId,
+                        workos.apiKey,
+                        email,
+                        password,
+                        options
+                    )
+                    .build()
+            )
+            .build()
+    )
+  }
+
+  /** Authenticates a user by verifying the Magic Auth code sent to the user’s email. */
+  fun authenticateWithMagicAuth(
+      clientId: String,
+      email: String,
+      code: String,
+      options: AuthenticationAdditionalOptions? = null
+  ): Authentication {
+    return workos.post(
+        "/user_management/authenticate",
+        Authentication::class.java,
+        RequestConfig.builder()
+            .data(
+                AuthenticationWithMagicAuthOptionsBuilder.create(
+                        clientId,
+                        workos.apiKey,
+                        email,
+                        code,
+                        options
+                    )
+                    .build()
+            )
+            .build()
     )
   }
 
   /**
-   * Authenticates a user with email and password.
+   * Use this endpoint to exchange a refresh token for a new access token. Refresh tokens are single
+   * use, so a new refresh token is returned.
    */
-  fun authenticateWithPassword(clientId: String, email: String, password: String, options: AuthenticationAdditionalOptions? = null): Authentication {
+  fun authenticateWithRefreshToken(
+      clientId: String,
+      refreshToken: String,
+      options: AuthenticationAdditionalOptions? = null
+  ): RefreshAuthentication {
     return workos.post(
-      "/user_management/authenticate",
-      Authentication::class.java,
-      RequestConfig.builder().data(
-        AuthenticationWithPasswordOptionsBuilder.create(
-          clientId, workos.apiKey, email, password, options
-        ).build()
-      ).build()
+        "/user_management/authenticate",
+        RefreshAuthentication::class.java,
+        RequestConfig.builder()
+            .data(
+                AuthenticationWithRefreshTokenOptionsBuilder.create(
+                        clientId,
+                        workos.apiKey,
+                        refreshToken,
+                        options
+                    )
+                    .build()
+            )
+            .build()
     )
   }
 
-  /**
-   * Authenticates a user by verifying the Magic Auth code sent to the user’s email.
-   */
-  fun authenticateWithMagicAuth(clientId: String, email: String, code: String, options: AuthenticationAdditionalOptions? = null): Authentication {
+  /** Authenticates a user with an unverified email and verifies their email address. */
+  fun authenticateWithEmailVerification(
+      clientId: String,
+      code: String,
+      pendingAuthenticationToken: String,
+      options: AuthenticationAdditionalOptions? = null
+  ): Authentication {
     return workos.post(
-      "/user_management/authenticate",
-      Authentication::class.java,
-      RequestConfig.builder().data(
-        AuthenticationWithMagicAuthOptionsBuilder.create(
-          clientId, workos.apiKey, email, code, options
-        ).build()
-      ).build()
+        "/user_management/authenticate",
+        Authentication::class.java,
+        RequestConfig.builder()
+            .data(
+                AuthenticationWithEmailVerificationOptionsBuilder.create(
+                        clientId,
+                        workos.apiKey,
+                        code,
+                        pendingAuthenticationToken,
+                        options
+                    )
+                    .build()
+            )
+            .build()
     )
   }
 
-  /**
-   * Use this endpoint to exchange a refresh token for a new access token. Refresh tokens are single use, so a new refresh token is returned.
-   */
-  fun authenticateWithRefreshToken(clientId: String, refreshToken: String, options: AuthenticationAdditionalOptions? = null): RefreshAuthentication {
+  /** Authenticates a user enrolled into MFA using time-based one-time password (TOTP). */
+  fun authenticateWithTotp(
+      clientId: String,
+      code: String,
+      authenticationChallengeId: String,
+      pendingAuthenticationToken: String,
+      options: AuthenticationAdditionalOptions? = null
+  ): Authentication {
     return workos.post(
-      "/user_management/authenticate",
-      RefreshAuthentication::class.java,
-      RequestConfig.builder().data(
-        AuthenticationWithRefreshTokenOptionsBuilder.create(
-          clientId, workos.apiKey, refreshToken, options
-        ).build()
-      ).build()
+        "/user_management/authenticate",
+        Authentication::class.java,
+        RequestConfig.builder()
+            .data(
+                AuthenticationWithTotpOptionsBuilder.create(
+                        clientId,
+                        workos.apiKey,
+                        code,
+                        authenticationChallengeId,
+                        pendingAuthenticationToken,
+                        options
+                    )
+                    .build()
+            )
+            .build()
     )
   }
 
-  /**
-   * Authenticates a user with an unverified email and verifies their email address.
-   */
-  fun authenticateWithEmailVerification(clientId: String, code: String, pendingAuthenticationToken: String, options: AuthenticationAdditionalOptions? = null): Authentication {
+  /** Authenticates a user into an organization they are a member of. */
+  fun authenticateWithOrganizationSelection(
+      clientId: String,
+      organizationId: String,
+      pendingAuthenticationToken: String,
+      options: AuthenticationAdditionalOptions? = null
+  ): Authentication {
     return workos.post(
-      "/user_management/authenticate",
-      Authentication::class.java,
-      RequestConfig.builder().data(
-        AuthenticationWithEmailVerificationOptionsBuilder.create(
-          clientId, workos.apiKey, code, pendingAuthenticationToken, options
-        ).build()
-      ).build()
+        "/user_management/authenticate",
+        Authentication::class.java,
+        RequestConfig.builder()
+            .data(
+                AuthenticationWithOrganizationSelectionOptionsBuilder.create(
+                        clientId,
+                        workos.apiKey,
+                        organizationId,
+                        pendingAuthenticationToken,
+                        options
+                    )
+                    .build()
+            )
+            .build()
     )
   }
 
-  /**
-   * Authenticates a user enrolled into MFA using time-based one-time password (TOTP).
-   */
-  fun authenticateWithTotp(clientId: String, code: String, authenticationChallengeId: String, pendingAuthenticationToken: String, options: AuthenticationAdditionalOptions? = null): Authentication {
-    return workos.post(
-      "/user_management/authenticate",
-      Authentication::class.java,
-      RequestConfig.builder().data(
-        AuthenticationWithTotpOptionsBuilder.create(
-          clientId, workos.apiKey, code, authenticationChallengeId, pendingAuthenticationToken, options
-        ).build()
-      ).build()
-    )
-  }
-
-  /**
-   * Authenticates a user into an organization they are a member of.
-   */
-  fun authenticateWithOrganizationSelection(clientId: String, organizationId: String, pendingAuthenticationToken: String, options: AuthenticationAdditionalOptions? = null): Authentication {
-    return workos.post(
-      "/user_management/authenticate",
-      Authentication::class.java,
-      RequestConfig.builder().data(
-        AuthenticationWithOrganizationSelectionOptionsBuilder.create(
-          clientId, workos.apiKey, organizationId, pendingAuthenticationToken, options
-        ).build()
-      ).build()
-    )
-  }
-
-  /**
-   * This hosts the public key that is used for verifying access tokens.
-   */
+  /** This hosts the public key that is used for verifying access tokens. */
   fun getJwksUrl(clientId: String): String {
-    return URIBuilder(workos.baseUrl)
-      .setPath("/sso/jwks/$clientId")
-      .toString()
+    return URIBuilder(workos.baseUrl).setPath("/sso/jwks/$clientId").toString()
   }
 
-  /**
-   * Get the details of an existing Magic Auth code.
-   */
+  /** Get the details of an existing Magic Auth code. */
   fun getMagicAuth(id: String): MagicAuth {
     return workos.get("/user_management/magic_auth/$id", MagicAuth::class.java)
   }
 
-  /**
-   * Creates a Magic Auth code that can be used to authenticate into your app.
-   */
+  /** Creates a Magic Auth code that can be used to authenticate into your app. */
   fun createMagicAuth(options: CreateMagicAuthOptions): MagicAuth {
     return workos.post(
-      "/user_management/magic_auth",
-      MagicAuth::class.java,
-      RequestConfig.builder().data(options).build()
+        "/user_management/magic_auth",
+        MagicAuth::class.java,
+        RequestConfig.builder().data(options).build()
     )
   }
 
   /**
-   * Sends a one-time authentication code to the user’s email address. The code
-   * expires in 10 minutes. To verify the code, authenticate the user with Magic Auth.
+   * Sends a one-time authentication code to the user’s email address. The code expires in 10
+   * minutes. To verify the code, authenticate the user with Magic Auth.
    */
-  @Deprecated("Please use `createMagicAuth` instead. This method will be removed in a future major version.")
+  @Deprecated(
+      "Please use `createMagicAuth` instead. This method will be removed in a future major version."
+  )
   fun sendMagicAuthCode(email: String) {
     workos.post(
-      "/user_management/magic_auth/send",
-      RequestConfig.builder().data(
-        SendMagicAuthCodeOptionsBuilder.create(
-          email
-        ).build()
-      ).build()
+        "/user_management/magic_auth/send",
+        RequestConfig.builder().data(SendMagicAuthCodeOptionsBuilder.create(email).build()).build()
     )
   }
 
-  /**
-   * Enrolls a user in a new authentication factor.
-   */
-  fun enrollAuthFactor(id: String, options: EnrolledAuthenticationFactorOptions? = null): EnrolledAuthenticationFactor {
+  /** Enrolls a user in a new authentication factor. */
+  fun enrollAuthFactor(
+      id: String,
+      options: EnrolledAuthenticationFactorOptions? = null
+  ): EnrolledAuthenticationFactor {
     return workos.post(
-      "/user_management/users/$id/auth_factors",
-      EnrolledAuthenticationFactor::class.java,
-      RequestConfig.builder().data(options ?: EnrolledAuthenticationFactorOptions()).build()
+        "/user_management/users/$id/auth_factors",
+        EnrolledAuthenticationFactor::class.java,
+        RequestConfig.builder().data(options ?: EnrolledAuthenticationFactorOptions()).build()
     )
   }
 
-  /**
-   * Get a list of all authentication factors of a given user.
-   */
+  /** Get a list of all authentication factors of a given user. */
   fun listAuthFactors(id: String): AuthenticationFactors {
     return workos.get(
-      "/user_management/users/$id/auth_factors",
-      AuthenticationFactors::class.java,
+        "/user_management/users/$id/auth_factors",
+        AuthenticationFactors::class.java,
     )
   }
 
-  /**
-   * Get the details of an existing email verification code.
-   */
+  /** Get the details of an existing email verification code. */
   fun getEmailVerification(id: String): EmailVerification {
     return workos.get("/user_management/email_verification/$id", EmailVerification::class.java)
   }
 
-  /**
-   * Get the details of an existing password reset token.
-   */
+  /** Get the details of an existing password reset token. */
   fun getPasswordReset(id: String): PasswordReset {
     return workos.get("/user_management/password_reset/$id", PasswordReset::class.java)
   }
 
-  /**
-   * Creates a password reset token that can be used to reset a user's password.
-   */
+  /** Creates a password reset token that can be used to reset a user's password. */
   fun createPasswordReset(options: CreatePasswordResetOptions): PasswordReset {
     return workos.post(
-      "/user_management/password_reset",
-      PasswordReset::class.java,
-      RequestConfig.builder().data(options).build()
+        "/user_management/password_reset",
+        PasswordReset::class.java,
+        RequestConfig.builder().data(options).build()
     )
   }
 
-  /**
-   * Send a password reset email and change the user’s password.
-   */
-  @Deprecated("Please use `createPasswordReset` instead. This method will be removed in a future major version.")
+  /** Send a password reset email and change the user’s password. */
+  @Deprecated(
+      "Please use `createPasswordReset` instead. This method will be removed in a future major version."
+  )
   fun sendPasswordResetEmail(email: String, passwordResetUrl: String) {
     return workos.post(
-      "/user_management/password_reset/send",
-      RequestConfig.builder().data(
-        SendPasswordResetEmailOptionsBuilder.create(
-          email, passwordResetUrl
-        ).build()
-      ).build()
+        "/user_management/password_reset/send",
+        RequestConfig.builder()
+            .data(SendPasswordResetEmailOptionsBuilder.create(email, passwordResetUrl).build())
+            .build()
     )
   }
 
-  /**
-   * Sets a new password using the `token` query parameter from the link that the user received.
-   */
+  /** Sets a new password using the `token` query parameter from the link that the user received. */
   fun resetPassword(token: String, newPassword: String): User {
     return workos.post(
-      "/user_management/password_reset/confirm",
-      User::class.java,
-      RequestConfig.builder().data(
-        ResetPasswordOptionsBuilder.create(
-          token, newPassword
-        ).build()
-      ).build()
+        "/user_management/password_reset/confirm",
+        User::class.java,
+        RequestConfig.builder()
+            .data(ResetPasswordOptionsBuilder.create(token, newPassword).build())
+            .build()
     )
   }
 
-  /**
-   * Get the details of an existing organization membership.
-   */
+  /** Get the details of an existing organization membership. */
   fun getOrganizationMembership(id: String): OrganizationMembership {
-    return workos.get("/user_management/organization_memberships/$id", OrganizationMembership::class.java)
-  }
-
-  /**
-   * Get a list of all organization memberships matching the criteria specified.
-   */
-  fun listOrganizationMemberships(options: ListOrganizationMembershipsOptions? = null): OrganizationMemberships {
     return workos.get(
-      "/user_management/organization_memberships",
-      OrganizationMemberships::class.java,
-      RequestConfig.builder().data(options ?: ListOrganizationMembershipsOptions()).build()
+        "/user_management/organization_memberships/$id",
+        OrganizationMembership::class.java
     )
   }
 
-  /**
-   * Creates a new organization membership for the given organization and user.
-   */
-  fun createOrganizationMembership(options: CreateOrganizationMembershipOptions): OrganizationMembership {
+  /** Get a list of all organization memberships matching the criteria specified. */
+  fun listOrganizationMemberships(
+      options: ListOrganizationMembershipsOptions? = null
+  ): OrganizationMemberships {
+    val params: Map<String, String> =
+        RequestConfig.toMap(options ?: ListOrganizationMembershipsOptions()) as Map<String, String>
+
+    return workos.get(
+        "/user_management/organization_memberships",
+        OrganizationMemberships::class.java,
+        RequestConfig.builder().params(params).build()
+    )
+  }
+
+  /** Creates a new organization membership for the given organization and user. */
+  fun createOrganizationMembership(
+      options: CreateOrganizationMembershipOptions
+  ): OrganizationMembership {
     return workos.post(
-      "/user_management/organization_memberships",
-      OrganizationMembership::class.java,
-      RequestConfig.builder().data(options).build()
+        "/user_management/organization_memberships",
+        OrganizationMembership::class.java,
+        RequestConfig.builder().data(options).build()
     )
   }
 
-  /**
-   * Update the details of an existing organization membership.
-   */
+  /** Update the details of an existing organization membership. */
   fun updateOrganizationMembership(id: String, roleSlug: String): OrganizationMembership {
     return workos.put(
-      "/user_management/organization_memberships/$id",
-      OrganizationMembership::class.java,
-      RequestConfig.builder().data(
-        UpdateOrganizationMembershipOptionsBuilder.create(
-          id, roleSlug
-        ).build()
-      ).build()
+        "/user_management/organization_memberships/$id",
+        OrganizationMembership::class.java,
+        RequestConfig.builder()
+            .data(UpdateOrganizationMembershipOptionsBuilder.create(id, roleSlug).build())
+            .build()
     )
   }
 
-  /**
-   * Deletes an existing organization membership.
-   */
+  /** Deletes an existing organization membership. */
   fun deleteOrganizationMembership(id: String) {
     workos.delete("/user_management/organization_memberships/$id")
   }
 
-  /**
-   * Deactivate an organization membership.
-   */
+  /** Deactivate an organization membership. */
   fun deactivateOrganizationMembership(id: String): OrganizationMembership {
-    return workos.put("/user_management/organization_memberships/$id/deactivate", OrganizationMembership::class.java)
+    return workos.put(
+        "/user_management/organization_memberships/$id/deactivate",
+        OrganizationMembership::class.java
+    )
   }
 
-  /**
-   * Reactivate an organization membership.
-   */
+  /** Reactivate an organization membership. */
   fun reactivateOrganizationMembership(id: String): OrganizationMembership {
-    return workos.put("/user_management/organization_memberships/$id/reactivate", OrganizationMembership::class.java)
+    return workos.put(
+        "/user_management/organization_memberships/$id/reactivate",
+        OrganizationMembership::class.java
+    )
   }
 
-  /**
-   * Get the details of an existing invitation.
-   */
+  /** Get the details of an existing invitation. */
   fun getInvitation(id: String): Invitation {
     return workos.get("/user_management/invitations/$id", Invitation::class.java)
   }
 
-  /**
-   * Find an existing invitation by token.
-   */
+  /** Find an existing invitation by token. */
   fun findInvitationByToken(token: String): Invitation {
     return workos.get("/user_management/invitations/by_token/$token", Invitation::class.java)
   }
 
-  /**
-   * Get a list of all the existing invitations matching the criteria specified.
-   */
+  /** Get a list of all the existing invitations matching the criteria specified. */
   fun listInvitations(options: ListInvitationsOptions? = null): Invitations {
+    val params: Map<String, String> =
+        RequestConfig.toMap(options ?: ListInvitationsOptions()) as Map<String, String>
+
     return workos.get(
-      "/user_management/invitations",
-      Invitations::class.java,
-      RequestConfig.builder().data(options ?: ListInvitationsOptions()).build()
+        "/user_management/invitations",
+        Invitations::class.java,
+        RequestConfig.builder().params(params).build()
     )
   }
 
-  /**
-   * Sends an invitation email to the recipient.
-   */
+  /** Sends an invitation email to the recipient. */
   fun sendInvitation(options: SendInvitationOptions): Invitation {
     return workos.post(
-      "/user_management/invitations",
-      Invitation::class.java,
-      RequestConfig.builder().data(options).build()
+        "/user_management/invitations",
+        Invitation::class.java,
+        RequestConfig.builder().data(options).build()
     )
   }
 
-  /**
-   * Revokes an existing invitation.
-   */
+  /** Revokes an existing invitation. */
   fun revokeInvitation(id: String): Invitation {
     return workos.post("/user_management/invitations/$id/revoke", Invitation::class.java)
   }
 
-  /**
-   * End a user's session. The user's browser should be redirected to this URL.
-   */
+  /** End a user's session. The user's browser should be redirected to this URL. */
   fun getLogoutUrl(sessionId: String): String {
     return URIBuilder(workos.baseUrl)
-      .setPath("/user_management/sessions/logout")
-      .addParameter("session_id", sessionId)
-      .toString()
+        .setPath("/user_management/sessions/logout")
+        .addParameter("session_id", sessionId)
+        .toString()
   }
 }

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -109,12 +109,7 @@ class UserManagementApiTest : TestBase() {
       ),
       users.data[0]
     )
-    assertEquals(
-      ListMetadata(
-        null, "user_234"
-      ),
-      users.listMetadata
-    )
+    assertEquals(ListMetadata(null, "user_234"), users.listMetadata)
   }
 
   @Test
@@ -138,14 +133,15 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val options = ListUsersOptionsBuilder()
-      .email("test01@example.com")
-      .organizationId("org_123")
-      .order(Order.Desc)
-      .limit(10)
-      .after("someAfterId")
-      .before("someBeforeId")
-      .build()
+    val options =
+      ListUsersOptionsBuilder()
+        .email("test01@example.com")
+        .organizationId("org_123")
+        .order(Order.Desc)
+        .limit(10)
+        .after("someAfterId")
+        .before("someBeforeId")
+        .build()
 
     val users = workos.userManagement.listUsers(options)
 
@@ -162,12 +158,7 @@ class UserManagementApiTest : TestBase() {
       ),
       users.data[0]
     )
-    assertEquals(
-      ListMetadata(
-        null, "user_234"
-      ),
-      users.listMetadata
-    )
+    assertEquals(ListMetadata(null, "user_234"), users.listMetadata)
   }
 
   @Test
@@ -185,7 +176,8 @@ class UserManagementApiTest : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "email": "test01@example.com",
         "password": "password",
         "first_name": "Test",
@@ -194,12 +186,13 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val options = CreateUserOptionsBuilder("test01@example.com")
-      .password("password")
-      .firstName("Test")
-      .lastName("User")
-      .emailVerified(true)
-      .build()
+    val options =
+      CreateUserOptionsBuilder("test01@example.com")
+        .password("password")
+        .firstName("Test")
+        .lastName("User")
+        .emailVerified(true)
+        .build()
 
     val user = workos.userManagement.createUser(options)
 
@@ -233,7 +226,8 @@ class UserManagementApiTest : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "id": "user_123",
         "password": "password",
         "first_name": "Test",
@@ -242,12 +236,13 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val options = UpdateUserOptionsBuilder("user_123")
-      .password("password")
-      .firstName("Test")
-      .lastName("User")
-      .emailVerified(true)
-      .build()
+    val options =
+      UpdateUserOptionsBuilder("user_123")
+        .password("password")
+        .firstName("Test")
+        .lastName("User")
+        .emailVerified(true)
+        .build()
 
     val user = workos.userManagement.updateUser("user_123", options)
 
@@ -270,9 +265,7 @@ class UserManagementApiTest : TestBase() {
   fun deleteUserShouldWorkAndReturnNothing() {
     stubResponse("/user_management/users/user_123", "")
 
-    assertDoesNotThrow() {
-      workos.userManagement.deleteUser("user_123")
-    }
+    assertDoesNotThrow() { workos.userManagement.deleteUser("user_123") }
   }
 
   @Test
@@ -300,7 +293,12 @@ class UserManagementApiTest : TestBase() {
 
   @Test
   fun getAuthorizationUrlShouldReturnValidUrl() {
-    val url = workos.userManagement.getAuthorizationUrl("client_id", "http://localhost:8080/redirect").provider(UserManagementProviderEnumType.AuthKit).build()
+    val url =
+      workos
+        .userManagement
+        .getAuthorizationUrl("client_id", "http://localhost:8080/redirect")
+        .provider(UserManagementProviderEnumType.AuthKit)
+        .build()
 
     assertEquals(
       "http://localhost:${getWireMockPort()}/user_management/authorize?client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fredirect&response_type=code&provider=authkit",
@@ -310,14 +308,17 @@ class UserManagementApiTest : TestBase() {
 
   @Test
   fun getAuthorizationUrlShouldAcceptAdditionalParams() {
-    val url = workos.userManagement.getAuthorizationUrl("client_id", "http://localhost:8080/redirect")
-      .connectionId("connection_value")
-      .domainHint("domain_hint")
-      .loginHint("login_hint")
-      .screenHint("screen_hint")
-      .provider(UserManagementProviderEnumType.AuthKit)
-      .state("state_value")
-      .build()
+    val url =
+      workos
+        .userManagement
+        .getAuthorizationUrl("client_id", "http://localhost:8080/redirect")
+        .connectionId("connection_value")
+        .domainHint("domain_hint")
+        .loginHint("login_hint")
+        .screenHint("screen_hint")
+        .provider(UserManagementProviderEnumType.AuthKit)
+        .state("state_value")
+        .build()
 
     assertEquals(
       "http://localhost:${getWireMockPort()}/user_management/authorize?client_id=client_id&redirect_uri=http%3A%2F%2Flocalhost%3A8080%2Fredirect&response_type=code&connection_id=connection_value&domain_hint=domain_hint&login_hint=login_hint&screen_hint=screen_hint&provider=authkit&state=state_value",
@@ -328,14 +329,19 @@ class UserManagementApiTest : TestBase() {
   @Test
   fun getAuthorizationUrlShouldValidateUrlParams() {
     assertThrows(IllegalArgumentException::class.java) {
-      workos.userManagement.getAuthorizationUrl("client_id", "http://localhost:8080/redirect").build()
+      workos
+        .userManagement
+        .getAuthorizationUrl("client_id", "http://localhost:8080/redirect")
+        .build()
     }
   }
 
   @Test
   fun getAuthorizationUrlShouldValidateUrlAdditionalParams() {
     assertThrows(IllegalArgumentException::class.java) {
-      workos.userManagement.getAuthorizationUrl("client_id", "http://localhost:8080/redirect")
+      workos
+        .userManagement
+        .getAuthorizationUrl("client_id", "http://localhost:8080/redirect")
         .connectionId("connection_value")
         .domainHint("domain_hint")
         .loginHint("login_hint")
@@ -372,7 +378,8 @@ class UserManagementApiTest : TestBase() {
           "reason": "Investigating an issue with the customer's account."
         }
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "client_id": "client_id",
         "client_secret": "apiKey",
         "grant_type": "authorization_code",
@@ -382,14 +389,15 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val response = workos.userManagement.authenticateWithCode(
-      "client_id",
-      "code_123",
-      AuthenticationAdditionalOptionsBuilder()
-        .ipAddress("192.0.2.1")
-        .userAgent("Mozilla/5.0")
-        .build()
-    )
+    val response =
+      workos.userManagement.authenticateWithCode(
+        "client_id",
+        "code_123",
+        AuthenticationAdditionalOptionsBuilder()
+          .ipAddress("192.0.2.1")
+          .userAgent("Mozilla/5.0")
+          .build()
+      )
 
     assertEquals("test01@example.com", response.user?.email)
   }
@@ -416,7 +424,8 @@ class UserManagementApiTest : TestBase() {
         "access_token": "access_token",
         "refresh_token": "refresh_token"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "client_id": "client_id",
         "client_secret": "apiKey",
         "grant_type": "password",
@@ -427,15 +436,16 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val response = workos.userManagement.authenticateWithPassword(
-      "client_id",
-      "test01@example.com",
-      "password",
-      AuthenticationAdditionalOptionsBuilder()
-        .ipAddress("192.0.2.1")
-        .userAgent("Mozilla/5.0")
-        .build()
-    )
+    val response =
+      workos.userManagement.authenticateWithPassword(
+        "client_id",
+        "test01@example.com",
+        "password",
+        AuthenticationAdditionalOptionsBuilder()
+          .ipAddress("192.0.2.1")
+          .userAgent("Mozilla/5.0")
+          .build()
+      )
 
     assertEquals("test01@example.com", response.user?.email)
   }
@@ -460,7 +470,8 @@ class UserManagementApiTest : TestBase() {
         },
         "organization_id": "org_456"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "client_id": "client_id",
         "client_secret": "apiKey",
         "grant_type": "urn:workos:oauth:grant-type:magic-auth:code",
@@ -471,15 +482,16 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val response = workos.userManagement.authenticateWithMagicAuth(
-      "client_id",
-      "test01@example.com",
-      "code_123",
-      AuthenticationAdditionalOptionsBuilder()
-        .ipAddress("192.0.2.1")
-        .userAgent("Mozilla/5.0")
-        .build()
-    )
+    val response =
+      workos.userManagement.authenticateWithMagicAuth(
+        "client_id",
+        "test01@example.com",
+        "code_123",
+        AuthenticationAdditionalOptionsBuilder()
+          .ipAddress("192.0.2.1")
+          .userAgent("Mozilla/5.0")
+          .build()
+      )
 
     assertEquals("test01@example.com", response.user?.email)
   }
@@ -494,7 +506,8 @@ class UserManagementApiTest : TestBase() {
         "access_token": "access_token",
         "refresh_token": "refresh_token"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "client_id": "client_id",
         "client_secret": "apiKey",
         "grant_type": "refresh_token",
@@ -504,14 +517,15 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val response = workos.userManagement.authenticateWithRefreshToken(
-      "client_id",
-      "refresh_token",
-      AuthenticationAdditionalOptionsBuilder()
-        .ipAddress("192.0.2.1")
-        .userAgent("Mozilla/5.0")
-        .build()
-    )
+    val response =
+      workos.userManagement.authenticateWithRefreshToken(
+        "client_id",
+        "refresh_token",
+        AuthenticationAdditionalOptionsBuilder()
+          .ipAddress("192.0.2.1")
+          .userAgent("Mozilla/5.0")
+          .build()
+      )
 
     assertEquals(RefreshAuthentication("access_token", "refresh_token"), response)
   }
@@ -536,7 +550,8 @@ class UserManagementApiTest : TestBase() {
         },
         "organization_id": "org_456"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "client_id": "client_id",
         "client_secret": "apiKey",
         "grant_type": "urn:workos:oauth:grant-type:email-verification:code",
@@ -547,15 +562,16 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val response = workos.userManagement.authenticateWithEmailVerification(
-      "client_id",
-      "code_123",
-      "token_456",
-      AuthenticationAdditionalOptionsBuilder()
-        .ipAddress("192.0.2.1")
-        .userAgent("Mozilla/5.0")
-        .build()
-    )
+    val response =
+      workos.userManagement.authenticateWithEmailVerification(
+        "client_id",
+        "code_123",
+        "token_456",
+        AuthenticationAdditionalOptionsBuilder()
+          .ipAddress("192.0.2.1")
+          .userAgent("Mozilla/5.0")
+          .build()
+      )
 
     assertEquals("test01@example.com", response.user?.email)
   }
@@ -580,7 +596,8 @@ class UserManagementApiTest : TestBase() {
         },
         "organization_id": "org_456"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "client_id": "client_id",
         "client_secret": "apiKey",
         "grant_type": "urn:workos:oauth:grant-type:mfa-totp",
@@ -592,16 +609,17 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val response = workos.userManagement.authenticateWithTotp(
-      "client_id",
-      "code_123",
-      "challenge_789",
-      "token_456",
-      AuthenticationAdditionalOptionsBuilder()
-        .ipAddress("192.0.2.1")
-        .userAgent("Mozilla/5.0")
-        .build()
-    )
+    val response =
+      workos.userManagement.authenticateWithTotp(
+        "client_id",
+        "code_123",
+        "challenge_789",
+        "token_456",
+        AuthenticationAdditionalOptionsBuilder()
+          .ipAddress("192.0.2.1")
+          .userAgent("Mozilla/5.0")
+          .build()
+      )
 
     assertEquals("test01@example.com", response.user?.email)
   }
@@ -626,7 +644,8 @@ class UserManagementApiTest : TestBase() {
         },
         "organization_id": "org_456"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "client_id": "client_id",
         "client_secret": "apiKey",
         "grant_type": "urn:workos:oauth:grant-type:organization-selection",
@@ -637,15 +656,16 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val response = workos.userManagement.authenticateWithOrganizationSelection(
-      "client_id",
-      "org_123",
-      "token_456",
-      AuthenticationAdditionalOptionsBuilder()
-        .ipAddress("192.0.2.1")
-        .userAgent("Mozilla/5.0")
-        .build()
-    )
+    val response =
+      workos.userManagement.authenticateWithOrganizationSelection(
+        "client_id",
+        "org_123",
+        "token_456",
+        AuthenticationAdditionalOptionsBuilder()
+          .ipAddress("192.0.2.1")
+          .userAgent("Mozilla/5.0")
+          .build()
+      )
 
     assertEquals("test01@example.com", response.user?.email)
   }
@@ -654,10 +674,7 @@ class UserManagementApiTest : TestBase() {
   fun getJwksUrlShouldReturnValidUrlResponse() {
     val url = workos.userManagement.getJwksUrl("client_123")
 
-    assertEquals(
-      "http://localhost:${getWireMockPort()}/sso/jwks/client_123",
-      url
-    )
+    assertEquals("http://localhost:${getWireMockPort()}/sso/jwks/client_123", url)
   }
 
   @Test
@@ -704,7 +721,8 @@ class UserManagementApiTest : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "email": "test01@example.com",
         "invitation_token": null
       }"""
@@ -732,9 +750,7 @@ class UserManagementApiTest : TestBase() {
   fun sendMagicAuthCodeShouldWorkAndReturnNothing() {
     stubResponse("/user_management/magic_auth/send", "")
 
-    assertDoesNotThrow() {
-      workos.userManagement.sendMagicAuthCode("test01@example.com")
-    }
+    assertDoesNotThrow() { workos.userManagement.sendMagicAuthCode("test01@example.com") }
   }
 
   @Test
@@ -766,17 +782,19 @@ class UserManagementApiTest : TestBase() {
           "user_id": "user_123"
         }
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "type": "totp",
         "totp_issuer": "Foo Corp",
         "totp_user": "test01@example.com"
       }"""
     )
 
-    val options = EnrolledAuthenticationFactorOptionsBuilder()
-      .totpUser("test01@example.com")
-      .totpIssuer("Foo Corp")
-      .build()
+    val options =
+      EnrolledAuthenticationFactorOptionsBuilder()
+        .totpUser("test01@example.com")
+        .totpIssuer("Foo Corp")
+        .build()
 
     val enrolledAuthenticationFactor = workos.userManagement.enrollAuthFactor("user_123", options)
 
@@ -856,12 +874,7 @@ class UserManagementApiTest : TestBase() {
       ),
       authenticationFactors.data[0]
     )
-    assertEquals(
-      ListMetadata(
-        null, "auth_factor_234"
-      ),
-      authenticationFactors.listMetadata
-    )
+    assertEquals(ListMetadata(null, "auth_factor_234"), authenticationFactors.listMetadata)
   }
 
   @Test
@@ -967,7 +980,10 @@ class UserManagementApiTest : TestBase() {
     stubResponse("/user_management/password_reset/send", "")
 
     assertDoesNotThrow() {
-      workos.userManagement.sendPasswordResetEmail("test01@example.com", "https://your-app.com/reset-password")
+      workos.userManagement.sendPasswordResetEmail(
+        "test01@example.com",
+        "https://your-app.com/reset-password"
+      )
     }
   }
 
@@ -986,7 +1002,8 @@ class UserManagementApiTest : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "token": "token_123",
         "new_password": "new_password"
       }"""
@@ -1069,7 +1086,10 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val organizationMemberships = workos.userManagement.listOrganizationMemberships(ListOrganizationMembershipsOptionsBuilder().build())
+    val organizationMemberships =
+      workos.userManagement.listOrganizationMemberships(
+        ListOrganizationMembershipsOptionsBuilder().build()
+      )
 
     assertEquals(
       OrganizationMembership(
@@ -1083,12 +1103,7 @@ class UserManagementApiTest : TestBase() {
       ),
       organizationMemberships.data[0]
     )
-    assertEquals(
-      ListMetadata(
-        null, "om_234"
-      ),
-      organizationMemberships.listMetadata
-    )
+    assertEquals(ListMetadata(null, "om_234"), organizationMemberships.listMetadata)
   }
 
   @Test
@@ -1117,20 +1132,21 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val options = ListOrganizationMembershipsOptionsBuilder()
-      .userId("id_456")
-      .organizationId("org_789")
-      .statuses(
-        listOf<OrganizationMembershipStatusEnumType>(
-          OrganizationMembershipStatusEnumType.Active,
-          OrganizationMembershipStatusEnumType.Inactive
+    val options =
+      ListOrganizationMembershipsOptionsBuilder()
+        .userId("id_456")
+        .organizationId("org_789")
+        .statuses(
+          listOf<OrganizationMembershipStatusEnumType>(
+            OrganizationMembershipStatusEnumType.Active,
+            OrganizationMembershipStatusEnumType.Inactive
+          )
         )
-      )
-      .order(Order.Desc)
-      .limit(10)
-      .after("someAfterId")
-      .before("someBeforeId")
-      .build()
+        .order(Order.Desc)
+        .limit(10)
+        .after("someAfterId")
+        .before("someBeforeId")
+        .build()
 
     val organizationMemberships = workos.userManagement.listOrganizationMemberships(options)
 
@@ -1146,12 +1162,7 @@ class UserManagementApiTest : TestBase() {
       ),
       organizationMemberships.data[0]
     )
-    assertEquals(
-      ListMetadata(
-        null, "om_234"
-      ),
-      organizationMemberships.listMetadata
-    )
+    assertEquals(ListMetadata(null, "om_234"), organizationMemberships.listMetadata)
   }
 
   @Test
@@ -1170,16 +1181,16 @@ class UserManagementApiTest : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "user_id": "user_456",
         "organization_id": "org_789",
         "role_slug": "admin"
       }"""
     )
 
-    val options = CreateOrganizationMembershipOptionsBuilder("user_456", "org_789")
-      .roleSlug("admin")
-      .build()
+    val options =
+      CreateOrganizationMembershipOptionsBuilder("user_456", "org_789").roleSlug("admin").build()
 
     val organizationMembership = workos.userManagement.createOrganizationMembership(options)
 
@@ -1219,7 +1230,8 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val organizationMembership = workos.userManagement.updateOrganizationMembership("om_123", "member")
+    val organizationMembership =
+      workos.userManagement.updateOrganizationMembership("om_123", "member")
 
     assertEquals(
       OrganizationMembership(
@@ -1239,9 +1251,7 @@ class UserManagementApiTest : TestBase() {
   fun deleteOrganizationMembershipShouldWorkAndReturnNothing() {
     stubResponse("/user_management/organization_memberships/om_123", "")
 
-    assertDoesNotThrow() {
-      workos.userManagement.deleteOrganizationMembership("om_123")
-    }
+    assertDoesNotThrow() { workos.userManagement.deleteOrganizationMembership("om_123") }
   }
 
   @Test
@@ -1441,12 +1451,7 @@ class UserManagementApiTest : TestBase() {
       ),
       invitations.data[0]
     )
-    assertEquals(
-      ListMetadata(
-        null, "invitation_234"
-      ),
-      invitations.listMetadata
-    )
+    assertEquals(ListMetadata(null, "invitation_234"), invitations.listMetadata)
   }
 
   @Test
@@ -1477,14 +1482,15 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val options = ListInvitationsOptionsBuilder()
-      .email("test01@example.com")
-      .organizationId("org_123")
-      .order(Order.Desc)
-      .limit(10)
-      .after("someAfterId")
-      .before("someBeforeId")
-      .build()
+    val options =
+      ListInvitationsOptionsBuilder()
+        .email("test01@example.com")
+        .organizationId("org_123")
+        .order(Order.Desc)
+        .limit(10)
+        .after("someAfterId")
+        .before("someBeforeId")
+        .build()
 
     val invitations = workos.userManagement.listInvitations(options)
 
@@ -1505,12 +1511,7 @@ class UserManagementApiTest : TestBase() {
       ),
       invitations.data[0]
     )
-    assertEquals(
-      ListMetadata(
-        null, "invitation_234"
-      ),
-      invitations.listMetadata
-    )
+    assertEquals(ListMetadata(null, "invitation_234"), invitations.listMetadata)
   }
 
   @Test
@@ -1531,7 +1532,8 @@ class UserManagementApiTest : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
-      requestBody = """{
+      requestBody =
+      """{
         "email": "test01@example.com",
         "organization_id": "org_456",
         "expires_in_days": 10,
@@ -1540,12 +1542,13 @@ class UserManagementApiTest : TestBase() {
       }"""
     )
 
-    val options = SendInvitationOptionsBuilder("test01@example.com")
-      .organizationId("org_456")
-      .expiresInDays(10)
-      .inviterUserId("user_789")
-      .roleSlug("admin")
-      .build()
+    val options =
+      SendInvitationOptionsBuilder("test01@example.com")
+        .organizationId("org_456")
+        .expiresInDays(10)
+        .inviterUserId("user_789")
+        .roleSlug("admin")
+        .build()
 
     val invitation = workos.userManagement.sendInvitation(options)
 


### PR DESCRIPTION
## Description
Don't be fooled by the line count, it's mostly my editor fixing spacing issues.

`data` gets passed into a request which is then used to form the request body. In the case of a `GET` though there isn't a body, but there can be URL parameters. Data was being passed into list endpoints for UM, but because there is no body with a `GET` it was being ignored. 

This fixes that by parsing `data` as a map and using it as URL parameters for list requests.


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
