### PR TITLE
Rename `invitationCode` to `invitationToken`

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationAdditionalOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationAdditionalOptionsBuilder.kt
@@ -5,19 +5,19 @@ import com.workos.usermanagement.types.AuthenticationAdditionalOptions
 /**
  * Builder for options when authenticating with an authorization code.
  *
- * @param invitationCode The token of an invitation. The invitation should be in the pending state.
+ * @param invitationToken The token of an invitation. The invitation should be in the pending state.
  * @param ipAddress The IP address of the request from the user who is attempting to authenticate.
  * @param userAgent The user agent of the request from the user who is attempting to authenticate.
  */
 class AuthenticationAdditionalOptionsBuilder(
-  private var invitationCode: String? = null,
+  private var invitationToken: String? = null,
   private var ipAddress: String? = null,
   private var userAgent: String? = null
 ) {
   /**
    * Invitation Code
    */
-  fun invitationCode(value: String) = apply { invitationCode = value }
+  fun invitationToken(value: String) = apply { invitationToken = value }
 
   /**
    * IP Address
@@ -34,7 +34,7 @@ class AuthenticationAdditionalOptionsBuilder(
    */
   fun build(): AuthenticationAdditionalOptions {
     return AuthenticationAdditionalOptions(
-      invitationCode = this.invitationCode,
+      invitationToken = this.invitationToken,
       ipAddress = this.ipAddress,
       userAgent = this.userAgent,
     )

--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithCodeOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithCodeOptionsBuilder.kt
@@ -26,7 +26,7 @@ class AuthenticationWithCodeOptionsBuilder(
       clientSecret = this.clientSecret,
       grantType = "authorization_code",
       code = this.code,
-      invitationCode = this.options?.invitationCode,
+      invitationToken = this.options?.invitationToken,
       ipAddress = this.options?.ipAddress,
       userAgent = this.options?.userAgent,
     )

--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithEmailVerificationOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithEmailVerificationOptionsBuilder.kt
@@ -29,7 +29,7 @@ class AuthenticationWithEmailVerificationOptionsBuilder(
       grantType = "urn:workos:oauth:grant-type:email-verification:code",
       code = this.code,
       pendingAuthenticationToken = this.pendingAuthenticationToken,
-      invitationCode = this.options?.invitationCode,
+      invitationToken = this.options?.invitationToken,
       ipAddress = this.options?.ipAddress,
       userAgent = this.options?.userAgent,
     )

--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithMagicAuthOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithMagicAuthOptionsBuilder.kt
@@ -29,7 +29,7 @@ class AuthenticationWithMagicAuthOptionsBuilder(
       grantType = "urn:workos:oauth:grant-type:magic-auth:code",
       email = this.email,
       code = this.code,
-      invitationCode = this.options?.invitationCode,
+      invitationToken = this.options?.invitationToken,
       ipAddress = this.options?.ipAddress,
       userAgent = this.options?.userAgent,
     )

--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithOrganizationSelectionOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithOrganizationSelectionOptionsBuilder.kt
@@ -29,7 +29,7 @@ class AuthenticationWithOrganizationSelectionOptionsBuilder(
       grantType = "urn:workos:oauth:grant-type:organization-selection",
       organizationId = this.organizationId,
       pendingAuthenticationToken = this.pendingAuthenticationToken,
-      invitationCode = this.options?.invitationCode,
+      invitationToken = this.options?.invitationToken,
       ipAddress = this.options?.ipAddress,
       userAgent = this.options?.userAgent,
     )

--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithPasswordOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithPasswordOptionsBuilder.kt
@@ -29,7 +29,7 @@ class AuthenticationWithPasswordOptionsBuilder(
       grantType = "password",
       email = this.email,
       password = this.password,
-      invitationCode = this.options?.invitationCode,
+      invitationToken = this.options?.invitationToken,
       ipAddress = this.options?.ipAddress,
       userAgent = this.options?.userAgent,
     )

--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithRefreshTokenOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithRefreshTokenOptionsBuilder.kt
@@ -26,7 +26,7 @@ class AuthenticationWithRefreshTokenOptionsBuilder(
       clientSecret = this.clientSecret,
       grantType = "refresh_token",
       refreshToken = this.refreshToken,
-      invitationCode = this.options?.invitationCode,
+      invitationToken = this.options?.invitationToken,
       ipAddress = this.options?.ipAddress,
       userAgent = this.options?.userAgent,
     )

--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithTotpOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithTotpOptionsBuilder.kt
@@ -32,7 +32,7 @@ class AuthenticationWithTotpOptionsBuilder(
       code = this.code,
       authenticationChallengeId = this.authenticationChallengeId,
       pendingAuthenticationToken = this.pendingAuthenticationToken,
-      invitationCode = this.options?.invitationCode,
+      invitationToken = this.options?.invitationToken,
       ipAddress = this.options?.ipAddress,
       userAgent = this.options?.userAgent,
     )

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationAdditionalOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationAdditionalOptions.kt
@@ -11,8 +11,8 @@ open class AuthenticationAdditionalOptions(
    * a specific organization, attaching the token to a user's authenticate call
    * automatically provisions their membership to the organization.
    */
-  @JsonProperty("invitation_code")
-  open val invitationCode: String? = null,
+  @JsonProperty("invitation_token")
+  open val invitationToken: String? = null,
 
   /**
    * The IP address of the request from the user who is attempting to authenticate.

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithCodeOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithCodeOptions.kt
@@ -31,15 +31,15 @@ class AuthenticationWithCodeOptions @JvmOverloads constructor(
   @JsonProperty("code")
   val code: String,
 
-  @JsonProperty("invitation_code")
-  override val invitationCode: String? = null,
+  @JsonProperty("invitation_token")
+  override val invitationToken: String? = null,
 
   @JsonProperty("ip_address")
   override val ipAddress: String? = null,
 
   @JsonProperty("user_agent")
   override val userAgent: String? = null
-) : AuthenticationAdditionalOptions(invitationCode, ipAddress, userAgent) {
+) : AuthenticationAdditionalOptions(invitationToken, ipAddress, userAgent) {
   init {
     require(clientId.isNotBlank()) { "Client ID is required" }
     require(clientSecret.isNotBlank()) { "Client Secret is required" }

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithEmailVerificationOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithEmailVerificationOptions.kt
@@ -36,15 +36,15 @@ class AuthenticationWithEmailVerificationOptions @JvmOverloads constructor(
   @JsonProperty("pending_authentication_token")
   val pendingAuthenticationToken: String,
 
-  @JsonProperty("invitation_code")
-  override val invitationCode: String? = null,
+  @JsonProperty("invitation_token")
+  override val invitationToken: String? = null,
 
   @JsonProperty("ip_address")
   override val ipAddress: String? = null,
 
   @JsonProperty("user_agent")
   override val userAgent: String? = null
-) : AuthenticationAdditionalOptions(invitationCode, ipAddress, userAgent) {
+) : AuthenticationAdditionalOptions(invitationToken, ipAddress, userAgent) {
   init {
     require(clientId.isNotBlank()) { "Client ID is required" }
     require(clientSecret.isNotBlank()) { "Client Secret is required" }

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithMagicAuthOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithMagicAuthOptions.kt
@@ -36,15 +36,15 @@ class AuthenticationWithMagicAuthOptions @JvmOverloads constructor(
   @JsonProperty("code")
   val code: String,
 
-  @JsonProperty("invitation_code")
-  override val invitationCode: String? = null,
+  @JsonProperty("invitation_token")
+  override val invitationToken: String? = null,
 
   @JsonProperty("ip_address")
   override val ipAddress: String? = null,
 
   @JsonProperty("user_agent")
   override val userAgent: String? = null
-) : AuthenticationAdditionalOptions(invitationCode, ipAddress, userAgent) {
+) : AuthenticationAdditionalOptions(invitationToken, ipAddress, userAgent) {
   init {
     require(clientId.isNotBlank()) { "Client ID is required" }
     require(clientSecret.isNotBlank()) { "Client Secret is required" }

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithOrganizationSelectionOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithOrganizationSelectionOptions.kt
@@ -36,15 +36,15 @@ class AuthenticationWithOrganizationSelectionOptions @JvmOverloads constructor(
   @JsonProperty("pending_authentication_token")
   val pendingAuthenticationToken: String,
 
-  @JsonProperty("invitation_code")
-  override val invitationCode: String? = null,
+  @JsonProperty("invitation_token")
+  override val invitationToken: String? = null,
 
   @JsonProperty("ip_address")
   override val ipAddress: String? = null,
 
   @JsonProperty("user_agent")
   override val userAgent: String? = null
-) : AuthenticationAdditionalOptions(invitationCode, ipAddress, userAgent) {
+) : AuthenticationAdditionalOptions(invitationToken, ipAddress, userAgent) {
   init {
     require(clientId.isNotBlank()) { "Client ID is required" }
     require(clientSecret.isNotBlank()) { "Client Secret is required" }

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithPasswordOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithPasswordOptions.kt
@@ -36,15 +36,15 @@ class AuthenticationWithPasswordOptions @JvmOverloads constructor(
   @JsonProperty("password")
   val password: String,
 
-  @JsonProperty("invitation_code")
-  override val invitationCode: String? = null,
+  @JsonProperty("invitation_token")
+  override val invitationToken: String? = null,
 
   @JsonProperty("ip_address")
   override val ipAddress: String? = null,
 
   @JsonProperty("user_agent")
   override val userAgent: String? = null
-) : AuthenticationAdditionalOptions(invitationCode, ipAddress, userAgent) {
+) : AuthenticationAdditionalOptions(invitationToken, ipAddress, userAgent) {
   init {
     require(clientId.isNotBlank()) { "Client ID is required" }
     require(clientSecret.isNotBlank()) { "Client Secret is required" }

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithRefreshTokenOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithRefreshTokenOptions.kt
@@ -30,15 +30,15 @@ class AuthenticationWithRefreshTokenOptions @JvmOverloads constructor(
   @JsonProperty("refresh_token")
   val refreshToken: String,
 
-  @JsonProperty("invitation_code")
-  override val invitationCode: String? = null,
+  @JsonProperty("invitation_token")
+  override val invitationToken: String? = null,
 
   @JsonProperty("ip_address")
   override val ipAddress: String? = null,
 
   @JsonProperty("user_agent")
   override val userAgent: String? = null
-) : AuthenticationAdditionalOptions(invitationCode, ipAddress, userAgent) {
+) : AuthenticationAdditionalOptions(invitationToken, ipAddress, userAgent) {
   init {
     require(clientId.isNotBlank()) { "Client ID is required" }
     require(clientSecret.isNotBlank()) { "Client Secret is required" }

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithTotpOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithTotpOptions.kt
@@ -42,15 +42,15 @@ class AuthenticationWithTotpOptions @JvmOverloads constructor(
   @JsonProperty("pending_authentication_token")
   val pendingAuthenticationToken: String,
 
-  @JsonProperty("invitation_code")
-  override val invitationCode: String? = null,
+  @JsonProperty("invitation_token")
+  override val invitationToken: String? = null,
 
   @JsonProperty("ip_address")
   override val ipAddress: String? = null,
 
   @JsonProperty("user_agent")
   override val userAgent: String? = null
-) : AuthenticationAdditionalOptions(invitationCode, ipAddress, userAgent) {
+) : AuthenticationAdditionalOptions(invitationToken, ipAddress, userAgent) {
   init {
     require(clientId.isNotBlank()) { "Client ID is required" }
     require(clientSecret.isNotBlank()) { "Client Secret is required" }


### PR DESCRIPTION
## Description

This was a typo, and the API accepts `invitationToken`, not `invitationCode`.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
