### PR TITLE
Support for authentication events

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventData.kt
@@ -2,8 +2,8 @@ package com.workos.usermanagement.models
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.workos.usermanagement.types.AuthenticationEventTypeEnumType
 import com.workos.usermanagement.types.AuthenticationEventStatusEnumType
+import com.workos.usermanagement.types.AuthenticationEventTypeEnumType
 
 /**
  * Authentication events are emitted when a user attempts authentication using WorkOS.
@@ -19,7 +19,7 @@ import com.workos.usermanagement.types.AuthenticationEventStatusEnumType
 data class AuthenticationEventData @JsonCreator constructor(
   @JsonProperty("type")
   val type: AuthenticationEventTypeEnumType,
-  
+
   @JsonProperty("status")
   val status: AuthenticationEventStatusEnumType,
 
@@ -36,5 +36,5 @@ data class AuthenticationEventData @JsonCreator constructor(
   val userAgent: String? = null,
 
   @JsonProperty("error")
-  val error: AuthenticationEventDataError? = null
+  val error: AuthenticationEventError? = null
 )

--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventData.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventData.kt
@@ -1,0 +1,40 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.usermanagement.types.AuthenticationEventTypeEnumType
+import com.workos.usermanagement.types.AuthenticationEventStatusEnumType
+
+/**
+ * Authentication events are emitted when a user attempts authentication using WorkOS.
+ *
+ * @param type The type of authentication event (see enum values in [AuthenticationEventTypeEnumType])
+ * @param status The status of the authentication event (see enum values in [AuthenticationEventStatusEnumType]).
+ * @param email The email address of the user attempting authentication, if available.
+ * @param userId The ID of the user attempting authentication, if available.
+ * @param ipAddress The IP address of the authentication attempt, if available.
+ * @param userAgent The user agent of the authentication attempy, if available.
+ * @param error Error details if the event is for a failed authentication attempt.
+ */
+data class AuthenticationEventData @JsonCreator constructor(
+  @JsonProperty("type")
+  val type: AuthenticationEventTypeEnumType,
+  
+  @JsonProperty("status")
+  val status: AuthenticationEventStatusEnumType,
+
+  @JsonProperty("email")
+  val email: String? = null,
+
+  @JsonProperty("user_id")
+  val userId: String? = null,
+
+  @JsonProperty("ip_address")
+  val ipAddress: String? = null,
+
+  @JsonProperty("user_agent")
+  val userAgent: String? = null,
+
+  @JsonProperty("error")
+  val error: AuthenticationEventDataError? = null
+)

--- a/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventError.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/AuthenticationEventError.kt
@@ -1,0 +1,18 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * An authentication event error.
+ *
+ * @param code The error code.
+ * @param message The error message.
+ */
+data class AuthenticationEventError @JsonCreator constructor(
+  @JsonProperty("code")
+  val issuer: String,
+
+  @JsonProperty("message")
+  val user: String
+)

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationEventStatusEnumType.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationEventStatusEnumType.kt
@@ -1,0 +1,17 @@
+package com.workos.usermanagement.types
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+enum class AuthenticationEventStatusEnumType(val type: String) {
+  /**
+   * Failed
+   */
+  @JsonProperty("failed")
+  Failed("failed"),
+
+  /**
+   * Succeeded
+   */
+  @JsonProperty("succeeded")
+  Succeeded("succeeded"),
+}

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationEventTypeEnumType.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationEventTypeEnumType.kt
@@ -26,13 +26,13 @@ enum class AuthenticationEventTypeEnumType(val type: String) {
    */
   @JsonProperty("oauth")
   OAuth("oauth"),
-  
+
   /**
    * Password
    */
   @JsonProperty("password")
   Password("password"),
-  
+
   /**
    * SSO
    */

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationEventTypeEnumType.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationEventTypeEnumType.kt
@@ -1,0 +1,41 @@
+package com.workos.usermanagement.types
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+enum class AuthenticationEventTypeEnumType(val type: String) {
+  /**
+   * Email Verification
+   */
+  @JsonProperty("email_verification")
+  EmailVerification("email_verification"),
+
+  /**
+   * Magic Auth
+   */
+  @JsonProperty("magic_auth")
+  MagicAuth("magic_auth"),
+
+  /**
+   * MFA
+   */
+  @JsonProperty("mfa")
+  MFA("mfa"),
+
+  /**
+   * OAuth
+   */
+  @JsonProperty("oauth")
+  OAuth("oauth"),
+  
+  /**
+   * Password
+   */
+  @JsonProperty("password")
+  Password("password"),
+  
+  /**
+   * SSO
+   */
+  @JsonProperty("sso")
+  SSO("sso"),
+}

--- a/src/main/kotlin/com/workos/webhooks/models/AuthenticationEvent.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/AuthenticationEvent.kt
@@ -1,0 +1,20 @@
+package com.workos.webhooks.models
+
+import com.workos.usermanagement.models.AuthenticationEventData
+
+/**
+ * Webhook Event for `authentication.*` events.
+ */
+class AuthenticationEvent(
+  @JvmField
+  override val id: String,
+
+  @JvmField
+  override val event: EventType,
+
+  @JvmField
+  override val data: AuthenticationEventData,
+
+  @JvmField
+  override val createdAt: String
+) : WebhookEvent(id, event, data, createdAt)

--- a/src/main/kotlin/com/workos/webhooks/models/EventType.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/EventType.kt
@@ -12,6 +12,46 @@ enum class EventType(
   val value: String
 ) {
   /**
+   * Triggers when a user successfully verifies their email.
+   */
+  AuthenticationEmailVerificationSucceeded("authentication.email_verification_succeeded"),
+  
+  /**
+   * Triggers when a user fails to authenticate via Magic Auth.
+   */
+  AuthenticationMagicAuthFailed("authentication.magic_auth_failed"),
+  
+  /**
+   * Triggers when a user successfully authenticates via Magic Auth.
+   */
+  AuthenticationMagicAuthSucceeded("authentication.magic_auth_succeeded"),
+  
+  /**
+   * Triggers when a user successfully authenticates with a multi-factor authentication code.
+   */
+  AuthenticationMfaSucceeded("authentication.mfa_succeeded"),
+  
+  /**
+   * Triggers when a user successfully authenticates via OAuth.
+   */
+  AuthenticationOauthSucceeded("authentication.oauth_succeeded"),
+  
+  /**
+   * Triggers when a user fails to authenticate with password credentials.
+   */
+  AuthenticationPasswordFailed("authentication.password_failed"),
+  
+  /**
+   * Triggers when a user successfully authenticates with password credentials.
+   */
+  AuthenticationPasswordSucceeded("authentication.password_succeeded"),
+  
+  /**
+   * Triggers when a user successfully authenticates with Single Sign-On.
+   */
+  AuthenticationSsoSucceeded("authentication.sso_succeeded"),
+  
+  /**
    * Triggers when a Connection's state changes to active.
    */
   ConnectionActivated("connection.activated"),

--- a/src/main/kotlin/com/workos/webhooks/models/EventType.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/EventType.kt
@@ -15,42 +15,42 @@ enum class EventType(
    * Triggers when a user successfully verifies their email.
    */
   AuthenticationEmailVerificationSucceeded("authentication.email_verification_succeeded"),
-  
+
   /**
    * Triggers when a user fails to authenticate via Magic Auth.
    */
   AuthenticationMagicAuthFailed("authentication.magic_auth_failed"),
-  
+
   /**
    * Triggers when a user successfully authenticates via Magic Auth.
    */
   AuthenticationMagicAuthSucceeded("authentication.magic_auth_succeeded"),
-  
+
   /**
    * Triggers when a user successfully authenticates with a multi-factor authentication code.
    */
   AuthenticationMfaSucceeded("authentication.mfa_succeeded"),
-  
+
   /**
    * Triggers when a user successfully authenticates via OAuth.
    */
   AuthenticationOauthSucceeded("authentication.oauth_succeeded"),
-  
+
   /**
    * Triggers when a user fails to authenticate with password credentials.
    */
   AuthenticationPasswordFailed("authentication.password_failed"),
-  
+
   /**
    * Triggers when a user successfully authenticates with password credentials.
    */
   AuthenticationPasswordSucceeded("authentication.password_succeeded"),
-  
+
   /**
    * Triggers when a user successfully authenticates with Single Sign-On.
    */
   AuthenticationSsoSucceeded("authentication.sso_succeeded"),
-  
+
   /**
    * Triggers when a Connection's state changes to active.
    */

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -11,6 +11,7 @@ import com.workos.directorysync.models.Directory
 import com.workos.directorysync.models.Group
 import com.workos.directorysync.models.User
 import com.workos.sso.models.Connection
+import com.workos.usermanagement.models.AuthenticationEventData
 import com.workos.usermanagement.models.EmailVerificationEventData
 import com.workos.usermanagement.models.InvitationEventData
 import com.workos.usermanagement.models.MagicAuthEventData
@@ -39,6 +40,14 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
     val createdAt = mapper.readValue(rootNode?.get("created_at")?.traverse(), String::class.java)
 
     return when (eventType) {
+      EventType.AuthenticationEmailVerificationSucceeded -> AuthenticationEvent(id, eventType, deserializeData(data, AuthenticationEventData::class.java), createdAt)
+      EventType.AuthenticationMagicAuthFailed -> AuthenticationEvent(id, eventType, deserializeData(data, AuthenticationEventData::class.java), createdAt)
+      EventType.AuthenticationMagicAuthSucceeded -> AuthenticationEvent(id, eventType, deserializeData(data, AuthenticationEventData::class.java), createdAt)
+      EventType.AuthenticationMfaSucceeded -> AuthenticationEvent(id, eventType, deserializeData(data, AuthenticationEventData::class.java), createdAt)
+      EventType.AuthenticationOauthSucceeded -> AuthenticationEvent(id, eventType, deserializeData(data, AuthenticationEventData::class.java), createdAt)
+      EventType.AuthenticationPasswordFailed -> AuthenticationEvent(id, eventType, deserializeData(data, AuthenticationEventData::class.java), createdAt)
+      EventType.AuthenticationPasswordSucceeded -> AuthenticationEvent(id, eventType, deserializeData(data, AuthenticationEventData::class.java), createdAt)
+      EventType.AuthenticationSsoSucceeded -> AuthenticationEvent(id, eventType, deserializeData(data, AuthenticationEventData::class.java), createdAt)
       EventType.ConnectionActivated -> ConnectionActivatedEvent(id, eventType, deserializeData(data, Connection::class.java), createdAt)
       EventType.ConnectionDeactivated -> ConnectionDeactivatedEvent(id, eventType, deserializeData(data, Connection::class.java), createdAt)
       EventType.ConnectionDeleted -> ConnectionDeletedEvent(id, eventType, deserializeData(data, Connection::class.java), createdAt)

--- a/src/test/kotlin/com/workos/test/webhooks/AuthenticationWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/AuthenticationWebhookTests.kt
@@ -1,0 +1,199 @@
+package com.workos.test.webhooks
+
+import com.workos.test.TestBase
+import com.workos.webhooks.models.* // ktlint-disable no-wildcard-imports
+import org.junit.Test
+import org.junit.jupiter.api.Assertions.assertTrue
+import kotlin.test.assertEquals
+
+class AuthenticationWebhookTests : TestBase() {
+
+  private val userId = "user_01FMXJ0YAP7JX3377YFV2XPCJE"
+  private val email = "mary@example.com"
+
+  private val webhookId = "wh_01FMXKE185HQ2DQ84BH33HMF99"
+
+  private fun generateAuthenticationSucceededWebhookEvent(eventType: EventType, dataType: String): String {
+    return """
+    {
+      "id": "$webhookId",
+      "data": {
+        "type": "$dataType",
+        "status": "succeeded",
+        "user_id": "$userId",
+        "email": "$email",
+        "ip_address": "192.0.2.1",
+        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36"
+      },
+      "event": "${eventType.value}",
+      "created_at": "2024-07-20T10:15:23.713Z"
+    }
+    """
+  }
+
+  private fun generateAuthenticationFailedWebhookEvent(eventType: EventType, dataType: String): String {
+    return """
+    {
+      "id": "$webhookId",
+      "data": {
+        "type": "$dataType",
+        "status": "failed",
+        "user_id": "$userId",
+        "email": "$email",
+        "ip_address": "192.0.2.1",
+        "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/94.0.4606.81 Safari/537.36",
+        "error": {
+          "code": "error_code",
+          "message": "Error message."
+        }
+      },
+      "event": "${eventType.value}",
+      "created_at": "2024-07-20T10:15:23.713Z"
+    }
+    """
+  }
+
+  @Test
+  fun constructAuthenticationEmailVerificationSucceededEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateAuthenticationSucceededWebhookEvent(EventType.AuthenticationEmailVerificationSucceeded, "email_verification")
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is AuthenticationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as AuthenticationEvent).data.userId, userId)
+    assertEquals((webhook as AuthenticationEvent).data.email, email)
+  }
+
+  @Test
+  fun constructAuthenticationMagicAuthFailedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateAuthenticationFailedWebhookEvent(EventType.AuthenticationMagicAuthFailed, "magic_auth")
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is AuthenticationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as AuthenticationEvent).data.userId, userId)
+    assertEquals((webhook as AuthenticationEvent).data.email, email)
+  }
+
+  @Test
+  fun constructAuthenticationMagicAuthSucceededEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateAuthenticationSucceededWebhookEvent(EventType.AuthenticationMagicAuthSucceeded, "magic_auth")
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is AuthenticationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as AuthenticationEvent).data.userId, userId)
+    assertEquals((webhook as AuthenticationEvent).data.email, email)
+  }
+
+  @Test
+  fun constructAuthenticationMfaSucceededEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateAuthenticationSucceededWebhookEvent(EventType.AuthenticationMfaSucceeded, "mfa")
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is AuthenticationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as AuthenticationEvent).data.userId, userId)
+    assertEquals((webhook as AuthenticationEvent).data.email, email)
+  }
+
+  @Test
+  fun constructAuthenticationOauthSucceededEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateAuthenticationSucceededWebhookEvent(EventType.AuthenticationOauthSucceeded, "oauth")
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is AuthenticationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as AuthenticationEvent).data.userId, userId)
+    assertEquals((webhook as AuthenticationEvent).data.email, email)
+  }
+
+  @Test
+  fun constructAuthenticationPasswordFailedEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateAuthenticationFailedWebhookEvent(EventType.AuthenticationPasswordFailed, "password")
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is AuthenticationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as AuthenticationEvent).data.userId, userId)
+    assertEquals((webhook as AuthenticationEvent).data.email, email)
+  }
+
+  @Test
+  fun constructAuthenticationPasswordSucceededEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateAuthenticationSucceededWebhookEvent(EventType.AuthenticationPasswordSucceeded, "password")
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is AuthenticationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as AuthenticationEvent).data.userId, userId)
+    assertEquals((webhook as AuthenticationEvent).data.email, email)
+  }
+
+  @Test
+  fun constructAuthenticationSsoSucceededEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateAuthenticationSucceededWebhookEvent(EventType.AuthenticationSsoSucceeded, "sso")
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is AuthenticationEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as AuthenticationEvent).data.userId, userId)
+    assertEquals((webhook as AuthenticationEvent).data.email, email)
+  }
+}


### PR DESCRIPTION
## Description

Adds support for the currently released authentication events: https://workos.com/docs/events/authentication

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
