### PR TITLE
Add `organizationId` parameter for `refresh_token` authentication method

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -170,6 +170,7 @@ class UserManagementApi(private val workos: WorkOS) {
   fun authenticateWithRefreshToken(
     clientId: String,
     refreshToken: String,
+    organizationId: String? = null,
     options: AuthenticationAdditionalOptions? = null
   ): RefreshAuthentication {
     return workos.post(
@@ -181,6 +182,7 @@ class UserManagementApi(private val workos: WorkOS) {
             clientId,
             workos.apiKey,
             refreshToken,
+            organizationId,
             options
           )
             .build()

--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithRefreshTokenOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthenticationWithRefreshTokenOptionsBuilder.kt
@@ -9,12 +9,14 @@ import com.workos.usermanagement.types.AuthenticationWithRefreshTokenOptions
  * @param clientId Identifies the application making the request to the WorkOS server.
  * @param clientSecret Authenticates the application making the request to the WorkOS server.
  * @param refreshToken The `refresh_token` received from a successful authentication response.
+ * @param organizationId The organization to issue the new `access_token` for.
  * @param options The authentication options passed to the authentication request.
  */
 class AuthenticationWithRefreshTokenOptionsBuilder(
   private val clientId: String,
   private val clientSecret: String,
   private val refreshToken: String,
+  private val organizationId: String? = null,
   private val options: AuthenticationAdditionalOptions? = null
 ) {
   /**
@@ -26,6 +28,7 @@ class AuthenticationWithRefreshTokenOptionsBuilder(
       clientSecret = this.clientSecret,
       grantType = "refresh_token",
       refreshToken = this.refreshToken,
+      organizationId = this.organizationId,
       invitationToken = this.options?.invitationToken,
       ipAddress = this.options?.ipAddress,
       userAgent = this.options?.userAgent,
@@ -37,8 +40,8 @@ class AuthenticationWithRefreshTokenOptionsBuilder(
    */
   companion object {
     @JvmStatic
-    fun create(clientId: String, clientSecret: String, refreshToken: String, options: AuthenticationAdditionalOptions? = null): AuthenticationWithRefreshTokenOptionsBuilder {
-      return AuthenticationWithRefreshTokenOptionsBuilder(clientId, clientSecret, refreshToken, options)
+    fun create(clientId: String, clientSecret: String, refreshToken: String, organizationId: String? = null, options: AuthenticationAdditionalOptions? = null): AuthenticationWithRefreshTokenOptionsBuilder {
+      return AuthenticationWithRefreshTokenOptionsBuilder(clientId, clientSecret, refreshToken, organizationId, options)
     }
   }
 }

--- a/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithRefreshTokenOptions.kt
+++ b/src/main/kotlin/com/workos/usermanagement/types/AuthenticationWithRefreshTokenOptions.kt
@@ -30,6 +30,12 @@ class AuthenticationWithRefreshTokenOptions @JvmOverloads constructor(
   @JsonProperty("refresh_token")
   val refreshToken: String,
 
+  /**
+   * The organization to issue the new `access_token` for.
+   */
+  @JsonProperty("organization_id")
+  val organizationId: String? = null,
+
   @JsonProperty("invitation_token")
   override val invitationToken: String? = null,
 

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -521,6 +521,7 @@ class UserManagementApiTest : TestBase() {
       workos.userManagement.authenticateWithRefreshToken(
         "client_id",
         "refresh_token",
+        null,
         AuthenticationAdditionalOptionsBuilder()
           .ipAddress("192.0.2.1")
           .userAgent("Mozilla/5.0")


### PR DESCRIPTION
## Description

Updates the SDK method for the `refresh_token` grant type to allow the optional `organizationId` parameter.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[x] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
