### PR TITLE
Add support for FGA endpoints

### DIFF
--- a/src/main/kotlin/com/workos/WorkOS.kt
+++ b/src/main/kotlin/com/workos/WorkOS.kt
@@ -253,7 +253,6 @@ class WorkOS(
 
   private fun sendRequest(request: Request): String {
     if (request.url.path.contains("fga")) {
-      System.out.println("FGA: SENDING REQUEST WITH RETRY")
       return sendRequestWithRetry(request)
     }
 

--- a/src/main/kotlin/com/workos/WorkOS.kt
+++ b/src/main/kotlin/com/workos/WorkOS.kt
@@ -1,6 +1,5 @@
 package com.workos
 
-import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.github.kittinunf.fuel.core.FuelManager

--- a/src/main/kotlin/com/workos/WorkOS.kt
+++ b/src/main/kotlin/com/workos/WorkOS.kt
@@ -1,5 +1,6 @@
 package com.workos
 
+import com.fasterxml.jackson.core.type.TypeReference
 import com.fasterxml.jackson.databind.DeserializationFeature
 import com.fasterxml.jackson.module.kotlin.jacksonMapperBuilder
 import com.github.kittinunf.fuel.core.FuelManager
@@ -25,8 +26,18 @@ import com.workos.sso.SsoApi
 import com.workos.usermanagement.UserManagementApi
 import com.workos.webhooks.WebhooksApi
 import org.apache.http.client.utils.URIBuilder
+import java.io.IOException
 import java.lang.IllegalArgumentException
+import java.net.ConnectException
+import java.net.SocketTimeoutException
 import java.util.Properties
+import kotlin.random.Random
+import kotlin.time.Duration
+import kotlin.time.ExperimentalTime
+
+@OptIn(ExperimentalTime::class)
+val MINIMUM_SLEEP_TIME = Duration.milliseconds(500)
+val BACKOFF_MULTIPLER = 1.5
 
 /**
  * Global configuration class for interacting with the WorkOS API.
@@ -241,6 +252,11 @@ class WorkOS(
   }
 
   private fun sendRequest(request: Request): String {
+    if (request.url.path.contains("fga")) {
+      System.out.println("FGA: SENDING REQUEST WITH RETRY")
+      return sendRequestWithRetry(request)
+    }
+
     val (_, response) = request.responseString()
 
     var payload = String(response.data)
@@ -254,6 +270,82 @@ class WorkOS(
     }
 
     return payload
+  }
+
+  @OptIn(ExperimentalTime::class)
+  private fun sendRequestWithRetry(request: Request): String {
+    var requestException: Exception? = null
+    var response: Response? = null
+    var retryAttempts = 0
+
+    while (true) {
+      requestException = null
+
+      try {
+        val (_, res) = request.responseString()
+        response = res
+      } catch (e: IOException) {
+        requestException = e
+      } catch (e: InterruptedException) {
+        requestException = e
+      }
+
+      if (!shouldRetryRequest(response, retryAttempts, requestException)) {
+        break
+      }
+
+      retryAttempts += 1
+
+      try {
+        Thread.sleep(getSleepTime(retryAttempts).inWholeMilliseconds)
+      } catch (e: InterruptedException) {
+        Thread.currentThread().interrupt()
+      }
+    }
+
+    if (requestException != null) {
+      throw requestException
+    }
+
+    var payload = if (response != null) String(response.data) else ""
+
+    if (payload.isEmpty()) {
+      payload = "{}"
+    }
+
+    if (response != null && response.statusCode >= 400) {
+      handleResponseError(response, payload)
+    }
+
+    return payload
+  }
+
+  private fun shouldRetryRequest(response: Response?, retryAttempts: Int, requestException: Exception?): Boolean {
+    if (retryAttempts >= 3) {
+      return false
+    }
+
+    if ((requestException != null) && (requestException.cause != null) && (requestException.cause is ConnectException || requestException.cause is SocketTimeoutException)) {
+      return true
+    }
+
+    if ((requestException != null) && (requestException.cause != null) && (requestException.cause is IOException)) {
+      return true
+    }
+
+    if (response != null && response.statusCode >= 500) {
+      return true
+    }
+
+    return false
+  }
+
+  @OptIn(ExperimentalTime::class)
+  private fun getSleepTime(retryAttempt: Int): Duration {
+    var sleepTime: Duration = Duration.nanoseconds(MINIMUM_SLEEP_TIME.inWholeNanoseconds * Math.pow(BACKOFF_MULTIPLER, (retryAttempt + 1).toDouble()))
+    val jitter = Random.nextDouble(0.5, 1.5)
+    sleepTime = Duration.nanoseconds(sleepTime.inWholeNanoseconds * jitter)
+    return sleepTime
   }
 
   private fun <Res : Any> sendRequest(request: Request, responseType: Class<Res>): Res {

--- a/src/main/kotlin/com/workos/WorkOS.kt
+++ b/src/main/kotlin/com/workos/WorkOS.kt
@@ -16,6 +16,7 @@ import com.workos.common.http.GenericErrorResponse
 import com.workos.common.http.RequestConfig
 import com.workos.common.http.UnprocessableEntityExceptionResponse
 import com.workos.directorysync.DirectorySyncApi
+import com.workos.fga.FgaApi
 import com.workos.mfa.MfaApi
 import com.workos.organizations.OrganizationsApi
 import com.workos.passwordless.PasswordlessApi
@@ -107,6 +108,12 @@ class WorkOS(
    */
   @JvmField
   val webhooks = WebhooksApi()
+
+  /**
+   * Module for interacting with the FGA API.
+   */
+  @JvmField
+  val fga = FgaApi(this)
 
   /**
    * The base URL for making API requests to.

--- a/src/main/kotlin/com/workos/fga/FgaApi.kt
+++ b/src/main/kotlin/com/workos/fga/FgaApi.kt
@@ -15,6 +15,7 @@ import com.workos.fga.types.CreateResourceOptions
 import com.workos.fga.types.ListResourcesOptions
 import com.workos.fga.types.ListWarrantsOptions
 import com.workos.fga.types.QueryOptions
+import com.workos.fga.types.QueryRequestOptions
 import com.workos.fga.types.UpdateResourceOptions
 import com.workos.fga.types.WriteWarrantOptions
 
@@ -114,7 +115,14 @@ class FgaApi(private val workos: WorkOS) {
   }
 
   /** Perform a query in the current environment */
-  fun query(options: QueryOptions): QueryResponse {
-    return workos.post("/fga/v1/query", QueryResponse::class.java, RequestConfig.builder().data(options).build())
+  fun query(options: QueryOptions, requestOptions: QueryRequestOptions? = null): QueryResponse {
+    val config = RequestConfig.builder()
+      .data(options)
+
+    if (requestOptions != null) {
+      config.headers(mapOf("Warrant-Token" to requestOptions.warrantToken))
+    }
+
+    return workos.post("/fga/v1/query", QueryResponse::class.java, config.build())
   }
 }

--- a/src/main/kotlin/com/workos/fga/FgaApi.kt
+++ b/src/main/kotlin/com/workos/fga/FgaApi.kt
@@ -1,0 +1,107 @@
+package com.workos.fga
+
+import com.workos.WorkOS
+import com.workos.common.http.RequestConfig
+import com.workos.fga.models.*
+import com.workos.fga.types.*
+
+class FgaApi(private val workos: WorkOS) {
+  /** Get an existing resource. */
+  fun getResource(resourceType: String, resourceId: String): Resource {
+    return workos.get("/fga/v1/resources/$resourceType/$resourceId", Resource::class.java)
+  }
+
+  /** Get a list of all the existing resources matching the criteria specified */
+  fun listResources(options: ListResourcesOptions? = null): Resources {
+    val params: Map<String, String> =
+      RequestConfig.toMap(options ?: ListResourcesOptions()) as Map<String, String>
+
+    return workos.get(
+      "/fga/v1/resources",
+      Resources::class.java,
+      RequestConfig.builder().params(params).build()
+    )
+  }
+
+  /** Create a new resource in the current environment. */
+  fun createResource(options: CreateResourceOptions): Resource {
+    return workos.post(
+      "/fga/v1/resources",
+      Resource::class.java,
+      RequestConfig.builder().data(options).build()
+    )
+  }
+
+  /** Update an existing resource. */
+  fun updateResource(resourceType: String, resourceId: String, options: UpdateResourceOptions): Resource {
+    return workos.put(
+      "/fga/v1/resources/$resourceType/$resourceId",
+      Resource::class.java,
+      RequestConfig.builder().data(options).build()
+    )
+  }
+
+  /** Delete a resource in the current environment. */
+  fun deleteResource(resourceType: String, resourceId: String) {
+    workos.delete("/fga/v1/resources/$resourceType/$resourceId")
+  }
+
+  /** Get a list of all existing warrants matching the criteria specified */
+  fun listWarrants(options: ListWarrantsOptions? = null): Warrants {
+    val params: Map<String, String> =
+      RequestConfig.toMap(options ?: ListWarrantsOptions()) as Map<String, String>
+
+    return workos.get(
+      "/fga/v1/warrants",
+      Warrants::class.java,
+      RequestConfig.builder().params(params).build()
+    )
+  }
+
+  /** Perform a warrant write (create/delete) in the current environment */
+  fun writeWarrant(options: WriteWarrantOptions): WriteWarrantResponse {
+    return workos.post(
+      "/fga/v1/warrants",
+      WriteWarrantResponse::class.java,
+      RequestConfig.builder().data(options).build()
+    )
+  }
+
+  /** Performs multiple warrant writes in the current environment */
+  fun batchWriteWarrants(options: List<WriteWarrantOptions>): WriteWarrantResponse {
+    return workos.post(
+      "/fga/v1/warrants",
+      WriteWarrantResponse::class.java,
+      RequestConfig.builder().data(options).build()
+    )
+  }
+
+  /** Perform a warrant check in the current environment */
+  fun check(options: CheckOptions, requestOptions: CheckRequestOptions? = null): CheckResponse {
+    val config = RequestConfig.builder()
+      .data(options)
+
+    if (requestOptions != null) {
+      config.headers(mapOf("Warrant-Token" to requestOptions.warrantToken))
+    }
+
+    return workos.post("/fga/v1/check", CheckResponse::class.java, config.build())
+  }
+
+  /** Perform a batch warrant check in the current environment */
+  fun checkBatch(options: CheckBatchOptions, requestOptions: CheckRequestOptions? = null): Array<CheckResponse> {
+    val config = RequestConfig.builder()
+      .data(options)
+
+    if (requestOptions != null) {
+      config.headers(mapOf("Warrant-Token" to requestOptions.warrantToken))
+    }
+
+    return workos.post("/fga/v1/check", Array<CheckResponse>::class.java, config.build())
+  }
+
+  /** Perform a query in the current environment */
+  fun query(options: QueryOptions): QueryResponse {
+    return workos.post("/fga/v1/query", QueryResponse::class.java, RequestConfig.builder().data(options).build())
+  }
+}

--- a/src/main/kotlin/com/workos/fga/FgaApi.kt
+++ b/src/main/kotlin/com/workos/fga/FgaApi.kt
@@ -2,8 +2,21 @@ package com.workos.fga
 
 import com.workos.WorkOS
 import com.workos.common.http.RequestConfig
-import com.workos.fga.models.*
-import com.workos.fga.types.*
+import com.workos.fga.models.CheckResponse
+import com.workos.fga.models.QueryResponse
+import com.workos.fga.models.Resource
+import com.workos.fga.models.Resources
+import com.workos.fga.models.Warrants
+import com.workos.fga.models.WriteWarrantResponse
+import com.workos.fga.types.CheckBatchOptions
+import com.workos.fga.types.CheckOptions
+import com.workos.fga.types.CheckRequestOptions
+import com.workos.fga.types.CreateResourceOptions
+import com.workos.fga.types.ListResourcesOptions
+import com.workos.fga.types.ListWarrantsOptions
+import com.workos.fga.types.QueryOptions
+import com.workos.fga.types.UpdateResourceOptions
+import com.workos.fga.types.WriteWarrantOptions
 
 class FgaApi(private val workos: WorkOS) {
   /** Get an existing resource. */

--- a/src/main/kotlin/com/workos/fga/builders/CheckBatchOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/CheckBatchOptionsBuilder.kt
@@ -1,0 +1,27 @@
+package com.workos.fga.builders
+
+import com.workos.fga.types.CheckBatchOptions
+import com.workos.fga.types.WarrantCheckOptions
+
+class CheckBatchOptionsBuilder @JvmOverloads constructor(
+  private var checks: List<WarrantCheckOptions>,
+  private var debug: Boolean? = null,
+) {
+  fun checks(value: List<WarrantCheckOptions>) = apply { checks = value }
+
+  fun debug(value: Boolean) = apply { debug = value }
+
+  fun build(): CheckBatchOptions {
+    return CheckBatchOptions(
+      checks = this.checks,
+      debug = this.debug,
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(checks: List<WarrantCheckOptions>, debug: Boolean? = null): CheckBatchOptionsBuilder {
+      return CheckBatchOptionsBuilder(checks, debug)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/builders/CheckOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/CheckOptionsBuilder.kt
@@ -1,0 +1,38 @@
+package com.workos.fga.builders
+
+import com.workos.fga.types.CheckOptions
+import com.workos.fga.types.WarrantCheckOptions
+
+class CheckOptionsBuilder @JvmOverloads constructor(
+  private var op: String? = null,
+  private var checks: List<WarrantCheckOptions>,
+  private var debug: Boolean? = null,
+) {
+  constructor(checks: List<WarrantCheckOptions>, debug: Boolean? = null) : this(null, checks, debug)
+
+  fun op(value: String) = apply { op = value }
+
+  fun checks(value: List<WarrantCheckOptions>) = apply { checks = value }
+
+  fun debug(value: Boolean) = apply { debug = value }
+
+  fun build(): CheckOptions {
+    return CheckOptions(
+      op = this.op,
+      checks = this.checks,
+      debug = this.debug,
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(op: String, checks: List<WarrantCheckOptions>, debug: Boolean? = null): CheckOptionsBuilder {
+      return CheckOptionsBuilder(op, checks, debug)
+    }
+
+    @JvmStatic
+    fun create(checks: List<WarrantCheckOptions>, debug: Boolean? = null): CheckOptionsBuilder {
+      return CheckOptionsBuilder("", checks, debug)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/builders/CreateResourceOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/CreateResourceOptionsBuilder.kt
@@ -1,0 +1,30 @@
+package com.workos.fga.builders
+
+import com.workos.fga.types.CreateResourceOptions
+
+class CreateResourceOptionsBuilder @JvmOverloads constructor(
+  private var resourceType: String,
+  private var resourceId: String? = null,
+  private var meta: Map<String, String>? = null,
+) {
+  fun resourceType(value: String) = apply { resourceType = value }
+
+  fun resourceId(value: String) = apply { resourceId = value }
+
+  fun meta(value: Map<String, String>) = apply { meta = value }
+
+  fun build(): CreateResourceOptions {
+    return CreateResourceOptions(
+      resourceType = this.resourceType,
+      resourceId = this.resourceId,
+      meta = this.meta,
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(resourceType: String): CreateResourceOptionsBuilder {
+      return CreateResourceOptionsBuilder(resourceType)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/builders/ListResourcesOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/ListResourcesOptionsBuilder.kt
@@ -1,0 +1,77 @@
+package com.workos.fga.builders
+
+import com.workos.common.models.Order
+import com.workos.fga.types.ListResourcesOptions
+
+/**
+ * Builder for options when listing resources.
+ *
+ * @param resourceType Filter resources by their type.
+ * @param search Returns resources where resource_type or resource_id contains the search term.
+ * @param limit Maximum number of records to return.
+ * @param before Pagination cursor to receive records before a provided resource ID.
+ * @param after Pagination cursor to receive records after a provided resource ID.
+ * @param order Sort records in either ascending or descending order by created_at timestamp: "asc" or "desc".
+ */
+class ListResourcesOptionsBuilder @JvmOverloads constructor(
+  private var resourceType: String? = null,
+  private var search: String? = null,
+  private var limit: Int? = null,
+  private var before: String? = null,
+  private var after: String? = null,
+  private var order: Order? = null,
+) {
+  /**
+   * Resource Type
+   */
+  fun resourceType(value: String) = apply { resourceType = value }
+
+  /**
+   * Search
+   */
+  fun search(value: String) = apply { search = value }
+
+  /**
+   * Limit
+   */
+  fun limit(value: Int) = apply { limit = value }
+
+  /**
+   * Before
+   */
+  fun before(value: String) = apply { before = value }
+
+  /**
+   * After
+   */
+  fun after(value: String) = apply { after = value }
+
+  /**
+   * Sorting Order
+   */
+  fun order(value: Order) = apply { order = value }
+
+  /**
+   * Generates the ListResources options.
+   */
+  fun build(): ListResourcesOptions {
+    return ListResourcesOptions(
+      resourceType = this.resourceType,
+      search = this.search,
+      limit = this.limit,
+      before = this.before,
+      after = this.after,
+      order = this.order,
+    )
+  }
+
+  /**
+   * @suppress
+   */
+  companion object {
+    @JvmStatic
+    fun create(): ListResourcesOptionsBuilder {
+      return ListResourcesOptionsBuilder()
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/builders/ListWarrantsOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/ListWarrantsOptionsBuilder.kt
@@ -1,0 +1,92 @@
+package com.workos.fga.builders
+
+import com.workos.fga.types.ListWarrantsOptions
+
+/**
+ * Builder for options when listing warrants.
+ *
+ * @param resourceType Returns warrants whose resourceType matches this value. Required if resourceId or relation is specified.
+ * @param resourceId Returns warrants whose resourceId matches this value.
+ * @param relation Returns warrants whose relation matches this value.
+ * @param subjectType Returns warrants with a subject whose resourceType matches this value.
+ * @param subjectId Returns warrants with a subject whose resourceId matches this value.
+ * @param subjectRelation Returns warrants with a subject whose relation matches this value.
+ * @param limit Maximum number of records to return.
+ * @param after Pagination cursor to receive records after a provided warrant ID.
+ */
+class ListWarrantsOptionsBuilder @JvmOverloads constructor(
+  private var resourceType: String? = null,
+  private var resourceId: String? = null,
+  private var relation: String? = null,
+  private var subjectType: String? = null,
+  private var subjectId: String? = null,
+  private var subjectRelation: String? = null,
+  private var limit: Int? = null,
+  private var after: String? = null,
+) {
+  /**
+   * Resource Type
+   */
+  fun resourceType(value: String) = apply { resourceType = value }
+
+  /**
+   * Resource ID
+   */
+  fun resourceId(value: String) = apply { resourceId = value }
+
+  /**
+   * Resource Type
+   */
+  fun relation(value: String) = apply { relation = value }
+
+  /**
+   * Subject Type
+   */
+  fun subjectType(value: String) = apply { subjectType = value }
+
+  /**
+   * Subject ID
+   */
+  fun subjectId(value: String) = apply { subjectId = value }
+
+  /**
+   * Subject Relation
+   */
+  fun subjectRelation(value: String) = apply { subjectRelation = value }
+
+  /**
+   * Limit
+   */
+  fun limit(value: Int) = apply { limit = value }
+
+  /**
+   * After
+   */
+  fun after(value: String) = apply { after = value }
+
+  /**
+   * Generates the ListWarrants options.
+   */
+  fun build(): ListWarrantsOptions {
+    return ListWarrantsOptions(
+      resourceType = this.resourceType,
+      resourceId = this.resourceId,
+      relation = this.relation,
+      subjectType = this.subjectType,
+      subjectId = this.subjectId,
+      subjectRelation = this.subjectRelation,
+      limit = this.limit,
+      after = this.after,
+    )
+  }
+
+  /**
+   * @suppress
+   */
+  companion object {
+    @JvmStatic
+    fun create(): ListWarrantsOptionsBuilder {
+      return ListWarrantsOptionsBuilder()
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/builders/QueryOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/QueryOptionsBuilder.kt
@@ -1,0 +1,77 @@
+package com.workos.fga.builders
+
+import com.workos.common.models.Order
+import com.workos.fga.types.QueryOptions
+
+/**
+ * Builder for options when making a query.
+ *
+ * @param query Query to be executed.
+ * @param context Contextual data to use for the query.
+ * @param limit Maximum number of records to return.
+ * @param before Pagination cursor to receive records before a provided resource ID.
+ * @param after Pagination cursor to receive records after a provided resource ID.
+ * @param order Sort records in either ascending or descending order by created_at timestamp: "asc" or "desc".
+ */
+class QueryOptionsBuilder @JvmOverloads constructor(
+  private var query: String,
+  private var context: Map<String, Any>? = null,
+  private var limit: Int? = null,
+  private var before: String? = null,
+  private var after: String? = null,
+  private var order: Order? = null,
+) {
+  /**
+   * Query
+   */
+  fun query(value: String) = apply { query = value }
+
+  /**
+   * Context
+   */
+  fun context(value: Map<String, Any>) = apply { context = value }
+
+  /**
+   * Limit
+   */
+  fun limit(value: Int) = apply { limit = value }
+
+  /**
+   * Before
+   */
+  fun before(value: String) = apply { before = value }
+
+  /**
+   * After
+   */
+  fun after(value: String) = apply { after = value }
+
+  /**
+   * Sorting Order
+   */
+  fun order(value: Order) = apply { order = value }
+
+  /**
+   * Generates the ListResources options.
+   */
+  fun build(): QueryOptions {
+    return QueryOptions(
+      query = this.query,
+      context = this.context,
+      limit = this.limit,
+      before = this.before,
+      after = this.after,
+      order = this.order,
+    )
+  }
+
+  /**
+   * @suppress
+   */
+  companion object {
+    @JvmStatic
+    fun create(query: String): QueryOptionsBuilder {
+      return QueryOptionsBuilder(query)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/builders/UpdateResourceOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/UpdateResourceOptionsBuilder.kt
@@ -1,0 +1,22 @@
+package com.workos.fga.builders
+
+import com.workos.fga.types.UpdateResourceOptions
+
+class UpdateResourceOptionsBuilder @JvmOverloads constructor(
+  private var meta: Map<String, String>? = null,
+) {
+  fun meta(value: Map<String, String>) = apply { meta = value }
+
+  fun build(): UpdateResourceOptions {
+    return UpdateResourceOptions(
+      meta = this.meta,
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(): UpdateResourceOptionsBuilder {
+      return UpdateResourceOptionsBuilder()
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/builders/WriteWarrantOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/WriteWarrantOptionsBuilder.kt
@@ -1,0 +1,53 @@
+package com.workos.fga.builders
+
+import com.workos.fga.models.Subject
+import com.workos.fga.types.WriteWarrantOptions
+
+/**
+ * Builder for options when performing a warrant write.
+ *
+ * @param op The operation to perform on the warrant ("create"/"delete").
+ * @param resourceType The type of the resource. Must be one of your system's existing resource types.
+ * @param resourceId The unique ID of the resource.
+ * @param relation The relation for this resource to subject association. The relation must be valid per the resource type definition.
+ * @param subject (see [Subject]) The resource with the specified `relation` to the resource provided by resourceType and resourceId.
+ * @param policy A boolean expression that must evaluate to true for this warrant to apply. The expression can reference variables provided in the context attribute of access check requests.
+ */
+class WriteWarrantOptionsBuilder @JvmOverloads constructor(
+  private var op: String,
+  private var resourceType: String,
+  private var resourceId: String,
+  private var relation: String,
+  private var subject: Subject,
+  private var policy: String? = null,
+) {
+  fun op(value: String) = apply { op = value }
+
+  fun resourceType(value: String) = apply { resourceType = value }
+
+  fun resourceId(value: String) = apply { resourceId = value }
+
+  fun relation(value: String) = apply { relation = value }
+
+  fun subject(value: Subject) = apply { subject = value }
+
+  fun policy(value: String) = apply { policy = value }
+
+  fun build(): WriteWarrantOptions {
+    return WriteWarrantOptions(
+      op = this.op,
+      resourceType = this.resourceType,
+      resourceId = this.resourceId,
+      relation = this.relation,
+      subject = this.subject,
+      policy = this.policy,
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(op: String, resourceType: String, resourceId: String, relation: String, subject: Subject): WriteWarrantOptionsBuilder {
+      return WriteWarrantOptionsBuilder(op, resourceType, resourceId, relation, subject)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
@@ -1,0 +1,48 @@
+package com.workos.fga.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.fga.types.WarrantCheckOptions
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class CheckResponse @JsonCreator constructor(
+  @JsonProperty("result")
+  val result: String,
+
+  @JsonProperty("is_implicit")
+  val isImplicit: Boolean,
+
+  @JsonProperty("debug_info")
+  val debugInfo: DebugInfo? = null
+) {
+  fun Authorized(): Boolean {
+    return this.result == "authorized"
+  }
+}
+
+data class DebugInfo @JsonCreator constructor(
+  @JsonProperty("processing_time")
+  val processingTime: Int,
+
+  @JsonProperty("decision_tree")
+  val decisionTree: DecisionTreeNode
+)
+
+data class DecisionTreeNode @JsonCreator constructor(
+  @JsonProperty("check")
+  val check: WarrantCheckOptions,
+
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonProperty("policy")
+  val policy: String? = null,
+
+  @JsonProperty("decision")
+  val decision: String,
+
+  @JsonProperty("processing_time")
+  val processingTime: Int,
+
+  @JsonProperty("children")
+  val children: List<DecisionTreeNode>? = null
+)

--- a/src/main/kotlin/com/workos/fga/models/QueryResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/QueryResponse.kt
@@ -1,0 +1,15 @@
+package com.workos.fga.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.ListMetadata
+import com.workos.fga.types.QueryResult
+
+data class QueryResponse
+@JsonCreator constructor(
+  @JsonProperty("data")
+  val data: List<QueryResult>,
+
+  @JsonProperty("list_metadata")
+  val listMetadata: ListMetadata
+)

--- a/src/main/kotlin/com/workos/fga/models/Resource.kt
+++ b/src/main/kotlin/com/workos/fga/models/Resource.kt
@@ -1,0 +1,22 @@
+package com.workos.fga.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * A WorkOS resource
+ *
+ * @param resourceType The type of the resource.
+ * @param resourceId The unique ID of the resource.
+ * @param meta A JSON object containing additional information about the resource.
+ */
+data class Resource @JsonCreator constructor(
+  @JsonProperty("resource_type")
+  val resourceType: String,
+
+  @JsonProperty("resource_id")
+  val resourceId: String,
+
+  @JsonProperty("meta")
+  val meta: Map<String, String>? = null
+)

--- a/src/main/kotlin/com/workos/fga/models/Resources.kt
+++ b/src/main/kotlin/com/workos/fga/models/Resources.kt
@@ -1,0 +1,20 @@
+package com.workos.fga.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.ListMetadata
+
+/**
+ * A list of WorkOS [Resource]s
+ *
+ * @param data A list of [Resource]s.
+ * @param listMetadata [com.workos.common.models.ListMetadata].
+ */
+data class Resources
+@JsonCreator constructor(
+  @JsonProperty("data")
+  val data: List<Resource>,
+
+  @JsonProperty("list_metadata")
+  val listMetadata: ListMetadata
+)

--- a/src/main/kotlin/com/workos/fga/models/Subject.kt
+++ b/src/main/kotlin/com/workos/fga/models/Subject.kt
@@ -1,0 +1,24 @@
+package com.workos.fga.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * A WorkOS FGA subject
+ *
+ * @param resourceType The type of the resource. Must be one of your system's existing resource types.
+ * @param resourceId The unique ID of the resource.
+ * @param relation Specifies a relation required on the resource to be part of the subject group.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class Subject @JsonCreator constructor(
+  @JsonProperty("resource_type")
+  val resourceType: String,
+
+  @JsonProperty("resource_id")
+  val resourceId: String,
+
+  @JsonProperty("relation")
+  val relation: String? = null,
+)

--- a/src/main/kotlin/com/workos/fga/models/Warrant.kt
+++ b/src/main/kotlin/com/workos/fga/models/Warrant.kt
@@ -1,0 +1,30 @@
+package com.workos.fga.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * A WorkOS warrant
+ *
+ * @param resourceType The type of the resource. Must be one of your system's existing resource types.
+ * @param resourceId The unique ID of the resource.
+ * @param relation The relation for this resource to subject association. The relation must be valid per the resource type definition.
+ * @param subject (see [Subject]) The resource with the specified `relation` to the resource provided by resourceType and resourceId.
+ * @param policy A boolean expression that must evaluate to true for this warrant to apply. The expression can reference variables provided in the context attribute of access check requests.
+ */
+data class Warrant @JsonCreator constructor(
+  @JsonProperty("resource_type")
+  val resourceType: String,
+
+  @JsonProperty("resource_id")
+  val resourceId: String,
+
+  @JsonProperty("relation")
+  val relation: String,
+
+  @JsonProperty("subject")
+  val subject: Subject,
+
+  @JsonProperty("policy")
+  val policy: String? = null
+)

--- a/src/main/kotlin/com/workos/fga/models/Warrants.kt
+++ b/src/main/kotlin/com/workos/fga/models/Warrants.kt
@@ -1,0 +1,20 @@
+package com.workos.fga.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.ListMetadata
+
+/**
+ * A list of WorkOS [Warrant]s
+ *
+ * @param data A list of [Warrant]s.
+ * @param listMetadata [com.workos.common.models.ListMetadata].
+ */
+data class Warrants
+@JsonCreator constructor(
+  @JsonProperty("data")
+  val data: List<Warrant>,
+
+  @JsonProperty("list_metadata")
+  val listMetadata: ListMetadata
+)

--- a/src/main/kotlin/com/workos/fga/models/WriteWarrantResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/WriteWarrantResponse.kt
@@ -1,0 +1,9 @@
+package com.workos.fga.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+data class WriteWarrantResponse @JsonCreator constructor(
+  @JsonProperty("warrant_token")
+  val warrantToken: String
+)

--- a/src/main/kotlin/com/workos/fga/types/CheckBatchOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/CheckBatchOptions.kt
@@ -1,0 +1,23 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class CheckBatchOptions @JvmOverloads constructor(
+  /**
+   * The list of warrant checks to perform.
+   */
+  @JsonProperty("checks")
+  val checks: List<WarrantCheckOptions>,
+
+  @JsonProperty("debug")
+  val debug: Boolean? = null,
+) {
+  @JsonProperty("op")
+  val op: String = "batch"
+
+  init {
+    require(checks.isNotEmpty()) { "Checks is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/types/CheckOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/CheckOptions.kt
@@ -1,0 +1,30 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class CheckOptions @JvmOverloads constructor(
+  /**
+   * The operator to use when checks contains a list of more than one warrant check.
+   */
+  @JsonProperty("op")
+  val op: String? = null,
+
+  /**
+   * The list of warrant checks to perform.
+   */
+  @JsonProperty("checks")
+  val checks: List<WarrantCheckOptions>,
+
+  @JsonProperty("debug")
+  val debug: Boolean? = null,
+) {
+  init {
+    require(checks.isNotEmpty()) { "Checks is required" }
+
+    if (checks.size > 1) {
+      require(!op.isNullOrBlank()) { "Op is required when more than one check is passed" }
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/types/CheckRequestOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/CheckRequestOptions.kt
@@ -1,0 +1,8 @@
+package com.workos.fga.types
+
+class CheckRequestOptions constructor(
+  /**
+   * A valid token string from a previous write operation or latest. This is used to specify the desired consistency for this read operation.
+   */
+  val warrantToken: String? = null,
+)

--- a/src/main/kotlin/com/workos/fga/types/CreateResourceOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/CreateResourceOptions.kt
@@ -1,0 +1,29 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class CreateResourceOptions @JvmOverloads constructor(
+  /**
+   * The type of the resource.
+   */
+  @JsonProperty("resource_type")
+  val resourceType: String,
+
+  /**
+   * The unique ID of the resource. If one is not provided, a unique ID will be generated.
+   */
+  @JsonProperty("resource_id")
+  val resourceId: String? = null,
+
+  /**
+   * A JSON object containing additional information about the resource.
+   */
+  @JsonProperty("meta")
+  val meta: Map<String, String>? = null
+) {
+  init {
+    require(resourceType.isNotBlank()) { "Resource type is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/types/DeleteResourceOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/DeleteResourceOptions.kt
@@ -1,0 +1,22 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class DeleteResourceOptions @JvmOverloads constructor(
+  /**
+   * The type of the resource.
+   */
+  @JsonProperty("resource_type")
+  val resourceType: String,
+
+  /**
+   * The unique ID of the resource to be deleted.
+   */
+  @JsonProperty("resource_id")
+  val resourceId: String,
+) {
+  init {
+    require(resourceType.isNotBlank()) { "Resource type is required" }
+    require(resourceId.isNotBlank()) { "Resource id is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/types/GetResourceOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/GetResourceOptions.kt
@@ -1,0 +1,22 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonProperty
+
+class GetResourceOptions @JvmOverloads constructor(
+  /**
+   * The type of the resource.
+   */
+  @JsonProperty("resource_type")
+  val resourceType: String,
+
+  /**
+   * The unique ID of the resource to be fetched.
+   */
+  @JsonProperty("resource_id")
+  val resourceId: String,
+) {
+  init {
+    require(resourceType.isNotBlank()) { "Resource type is required" }
+    require(resourceId.isNotBlank()) { "Resource id is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/types/ListResourcesOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/ListResourcesOptions.kt
@@ -1,0 +1,26 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.Order
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class ListResourcesOptions @JvmOverloads constructor(
+  @JsonProperty("resource_type")
+  val resourceType: String? = null,
+
+  @JsonProperty("search")
+  val search: String? = null,
+
+  @JsonProperty("limit")
+  val limit: Int? = null,
+
+  @JsonProperty("order")
+  val order: Order? = null,
+
+  @JsonProperty("before")
+  val before: String? = null,
+
+  @JsonProperty("after")
+  val after: String? = null
+)

--- a/src/main/kotlin/com/workos/fga/types/ListWarrantsOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/ListWarrantsOptions.kt
@@ -1,0 +1,31 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class ListWarrantsOptions @JvmOverloads constructor(
+  @JsonProperty("resource_type")
+  val resourceType: String? = null,
+
+  @JsonProperty("resource_id")
+  val resourceId: String? = null,
+
+  @JsonProperty("relation")
+  val relation: String? = null,
+
+  @JsonProperty("subject_type")
+  val subjectType: String? = null,
+
+  @JsonProperty("subject_id")
+  val subjectId: String? = null,
+
+  @JsonProperty("subject_relation")
+  val subjectRelation: String? = null,
+
+  @JsonProperty("limit")
+  val limit: Int? = null,
+
+  @JsonProperty("after")
+  val after: String? = null
+)

--- a/src/main/kotlin/com/workos/fga/types/QueryOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/QueryOptions.kt
@@ -1,0 +1,36 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.Order
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class QueryOptions @JvmOverloads constructor(
+  /**
+   * Query to be executed.
+   */
+  @JsonProperty("q")
+  val query: String,
+
+  /**
+   * Contextual data to use for resolving the access check. This data will be used when evaluating warrant policies.
+   */
+  @JsonProperty("context")
+  val context: Map<String, Any>? = null,
+
+  @JsonProperty("limit")
+  val limit: Int? = null,
+
+  @JsonProperty("order")
+  val order: Order? = null,
+
+  @JsonProperty("before")
+  val before: String? = null,
+
+  @JsonProperty("after")
+  val after: String? = null
+) {
+  init {
+    require(query.isNotBlank()) { "Query is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/types/QueryRequestOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/QueryRequestOptions.kt
@@ -1,0 +1,8 @@
+package com.workos.fga.types
+
+class QueryRequestOptions constructor(
+  /**
+   * A valid token string from a previous write operation or latest. This is used to specify the desired consistency for this read operation.
+   */
+  val warrantToken: String? = null,
+)

--- a/src/main/kotlin/com/workos/fga/types/QueryResult.kt
+++ b/src/main/kotlin/com/workos/fga/types/QueryResult.kt
@@ -2,7 +2,6 @@ package com.workos.fga.types
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
-import com.workos.common.models.Order
 import com.workos.fga.models.Warrant
 
 @JsonInclude(JsonInclude.Include.NON_NULL)

--- a/src/main/kotlin/com/workos/fga/types/QueryResult.kt
+++ b/src/main/kotlin/com/workos/fga/types/QueryResult.kt
@@ -1,0 +1,33 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.common.models.Order
+import com.workos.fga.models.Warrant
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class QueryResult @JvmOverloads constructor(
+  @JsonProperty("resource_type")
+  val resourceType: String,
+
+  @JsonProperty("resource_id")
+  val resourceId: String,
+
+  @JsonProperty("relation")
+  val relation: String,
+
+  @JsonProperty("warrant")
+  val warrant: Warrant,
+
+  @JsonProperty("is_implicit")
+  val isImplicit: Boolean,
+
+  @JsonProperty("meta")
+  val meta: Map<String, String>? = null
+) {
+  init {
+    require(resourceType.isNotBlank()) { "Resource type is required" }
+    require(resourceId.isNotBlank()) { "Resource id is required" }
+    require(relation.isNotBlank()) { "Relation is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/types/UpdateResourceOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/UpdateResourceOptions.kt
@@ -1,0 +1,13 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class UpdateResourceOptions @JvmOverloads constructor(
+  /**
+   * A JSON object containing additional information about the resource.
+   */
+  @JsonProperty("meta")
+  val meta: Map<String, String>? = null
+)

--- a/src/main/kotlin/com/workos/fga/types/WarrantCheckOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/WarrantCheckOptions.kt
@@ -1,0 +1,45 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.fga.models.Subject
+
+class WarrantCheckOptions @JvmOverloads constructor(
+  /**
+   * The type of the resource.
+   */
+  @JsonProperty("resource_type")
+  val resourceType: String,
+
+  /**
+   * The unique ID of the resource.
+   */
+  @JsonProperty("resource_id")
+  val resourceId: String,
+
+  /**
+   * The relation for this resource to subject association. The relation must be valid per the resource type definition.
+   */
+  @JsonProperty("relation")
+  val relation: String,
+
+  /**
+   * The resource with the specified `relation` to the resource provided by resourceType and resourceId.
+   */
+  @JsonProperty("subject")
+  val subject: Subject,
+
+  /**
+   * Contextual data to use for resolving the access check. This data will be used when evaluating warrant policies.
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  @JsonProperty("context")
+  val context: Map<String, Any>? = null
+) {
+  init {
+    require(resourceType.isNotBlank()) { "Resource type is required" }
+    require(resourceId.isNotBlank()) { "Resource id is required" }
+    require(relation.isNotBlank()) { "Relation is required" }
+    require(subject.resourceType.isNotBlank() && subject.resourceId.isNotBlank()) { "Subject is required" }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/types/WriteWarrantOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/WriteWarrantOptions.kt
@@ -1,0 +1,51 @@
+package com.workos.fga.types
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.fga.models.Subject
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+class WriteWarrantOptions @JvmOverloads constructor(
+  /**
+   * Operation to perform for the given warrant (create/delete).
+   */
+  @JsonProperty("op")
+  val op: String,
+
+  /**
+   * The type of the resource.
+   */
+  @JsonProperty("resource_type")
+  val resourceType: String,
+
+  /**
+   * The unique ID of the resource.
+   */
+  @JsonProperty("resource_id")
+  val resourceId: String,
+
+  /**
+   * The relation for this resource to subject association. The relation must be valid per the resource type definition.
+   */
+  @JsonProperty("relation")
+  val relation: String,
+
+  /**
+   * The resource with the specified `relation` to the resource provided by resourceType and resourceId.
+   */
+  @JsonProperty("subject")
+  val subject: Subject,
+
+  /**
+   * A boolean expression that must evaluate to true for this warrant to apply. The expression can reference variables provided in the context attribute of access check requests.
+   */
+  @JsonProperty("policy")
+  val policy: String? = null,
+) {
+  init {
+    require(resourceType.isNotBlank()) { "Resource type is required" }
+    require(resourceId.isNotBlank()) { "Resource id is required" }
+    require(relation.isNotBlank()) { "Relation is required" }
+    require(subject.resourceType.isNotBlank() && subject.resourceId.isNotBlank()) { "Subject is required" }
+  }
+}

--- a/src/test/kotlin/com/workos/test/TestBase.kt
+++ b/src/test/kotlin/com/workos/test/TestBase.kt
@@ -4,7 +4,6 @@ import com.github.tomakehurst.wiremock.client.WireMock.* // ktlint-disable no-wi
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import com.github.tomakehurst.wiremock.matching.StringValuePattern
-import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import com.workos.WorkOS
 import org.junit.ClassRule

--- a/src/test/kotlin/com/workos/test/TestBase.kt
+++ b/src/test/kotlin/com/workos/test/TestBase.kt
@@ -4,6 +4,7 @@ import com.github.tomakehurst.wiremock.client.WireMock.* // ktlint-disable no-wi
 import com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import com.github.tomakehurst.wiremock.junit.WireMockRule
 import com.github.tomakehurst.wiremock.matching.StringValuePattern
+import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
 import com.github.tomakehurst.wiremock.stubbing.StubMapping
 import com.workos.WorkOS
 import org.junit.ClassRule
@@ -55,6 +56,46 @@ open class TestBase {
           .withBody(responseBody)
           .withHeader("X-Request-ID", "request_id_value")
       )
+
+    if (requestBody != null) {
+      mapping.withRequestBody(equalToJson(requestBody))
+    }
+
+    if (requestHeaders != null) {
+      for (header in requestHeaders.entries.iterator()) {
+        mapping.withHeader(header.key, equalTo(header.value))
+      }
+    }
+
+    val stub = stubFor(mapping)
+
+    stubs.add(stub)
+
+    return stub
+  }
+
+  fun stubResponseWithScenario(
+    url: String,
+    responseBody: String,
+    responseStatus: Int = 200,
+    params: Map<String, StringValuePattern> = emptyMap(),
+    requestBody: String? = null,
+    requestHeaders: Map<String, String>? = null,
+    scenarioName: String,
+    scenarioState: String,
+    nextScenarioState: String
+  ): StubMapping {
+    val mapping = any(urlPathEqualTo(url))
+      .inScenario(scenarioName)
+      .whenScenarioStateIs(scenarioState)
+      .withQueryParams(params)
+      .willReturn(
+        aResponse()
+          .withStatus(responseStatus)
+          .withBody(responseBody)
+          .withHeader("X-Request-ID", "request_id_value")
+      )
+      .willSetStateTo(nextScenarioState)
 
     if (requestBody != null) {
       mapping.withRequestBody(equalToJson(requestBody))

--- a/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
+++ b/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
@@ -1,20 +1,28 @@
 package com.workos.test.fga
 
 import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
-import com.workos.WorkOS
 import com.workos.common.exceptions.GenericServerException
 import com.workos.common.models.ListMetadata
 import com.workos.common.models.Order
-import com.workos.fga.builders.*
+import com.workos.fga.builders.CheckBatchOptionsBuilder
+import com.workos.fga.builders.CheckOptionsBuilder
+import com.workos.fga.builders.CreateResourceOptionsBuilder
+import com.workos.fga.builders.ListResourcesOptionsBuilder
+import com.workos.fga.builders.ListWarrantsOptionsBuilder
+import com.workos.fga.builders.QueryOptionsBuilder
+import com.workos.fga.builders.UpdateResourceOptionsBuilder
+import com.workos.fga.builders.WriteWarrantOptionsBuilder
 import com.workos.fga.models.Resource
 import com.workos.fga.models.Subject
 import com.workos.fga.models.Warrant
-import com.workos.fga.types.DeleteResourceOptions
-import com.workos.fga.types.GetResourceOptions
 import com.workos.fga.types.WarrantCheckOptions
 import com.workos.test.TestBase
 import org.junit.jupiter.api.Assertions.assertDoesNotThrow
-import kotlin.test.*
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
 
 class FgaApiTest : TestBase() {
   val workos = createWorkOSClient()
@@ -513,7 +521,7 @@ class FgaApiTest : TestBase() {
       """{
         "warrant_token": "new_token"
       }""",
-      requestBody=
+      requestBody =
       """{
         "op": "create",
         "resource_type": "role",
@@ -542,7 +550,7 @@ class FgaApiTest : TestBase() {
       """{
         "warrant_token": "new_token"
       }""",
-      requestBody=
+      requestBody =
       """{
         "op": "delete",
         "resource_type": "role",
@@ -571,7 +579,7 @@ class FgaApiTest : TestBase() {
       """{
         "warrant_token": "new_token"
       }""",
-      requestBody=
+      requestBody =
       """[
         {
           "op": "delete",
@@ -614,7 +622,7 @@ class FgaApiTest : TestBase() {
         "result": "authorized",
         "is_implicit": false
       }""",
-      requestBody=
+      requestBody =
       """{
         "checks": [
           {
@@ -709,7 +717,7 @@ class FgaApiTest : TestBase() {
           }
         }
       }""",
-      requestBody=
+      requestBody =
       """{
         "checks": [
           {
@@ -796,7 +804,7 @@ class FgaApiTest : TestBase() {
           "is_implicit": true
         }
       ]""",
-      requestBody=
+      requestBody =
       """{
         "op": "batch",
         "checks": [
@@ -825,16 +833,16 @@ class FgaApiTest : TestBase() {
     val options = CheckBatchOptionsBuilder(
       listOf(
         WarrantCheckOptions(
-            "role",
-            "admin",
-            "member",
-            Subject("user", "tony-stark")
+          "role",
+          "admin",
+          "member",
+          Subject("user", "tony-stark")
         ),
         WarrantCheckOptions(
-            "tenant",
-            "stark-industries",
-            "member",
-            Subject("user", "tony-stark")
+          "tenant",
+          "stark-industries",
+          "member",
+          Subject("user", "tony-stark")
         )
       )
     ).build()
@@ -929,7 +937,7 @@ class FgaApiTest : TestBase() {
           }
         }
       ]""",
-      requestBody=
+      requestBody =
       """{
         "op": "batch",
         "checks": [

--- a/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
+++ b/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
@@ -1,0 +1,1083 @@
+package com.workos.test.fga
+
+import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
+import com.workos.WorkOS
+import com.workos.common.exceptions.GenericServerException
+import com.workos.common.models.ListMetadata
+import com.workos.common.models.Order
+import com.workos.fga.builders.*
+import com.workos.fga.models.Resource
+import com.workos.fga.models.Subject
+import com.workos.fga.models.Warrant
+import com.workos.fga.types.DeleteResourceOptions
+import com.workos.fga.types.GetResourceOptions
+import com.workos.fga.types.WarrantCheckOptions
+import com.workos.test.TestBase
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import kotlin.test.*
+
+class FgaApiTest : TestBase() {
+  val workos = createWorkOSClient()
+
+  @Test
+  fun getResourceShouldReturnValidResourceObject() {
+    stubResponse(
+      "/fga/v1/resources/user/user_123",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123"
+      }"""
+    )
+
+    val resource = workos.fga.getResource("user", "user_123")
+
+    assertEquals(
+      Resource("user", "user_123"),
+      resource
+    )
+  }
+
+  @Test
+  fun getResourceShouldFailAfterMaxRetries() {
+    stubResponse(
+      "/fga/v1/resources/user/user_123",
+      """{
+        "code": "internal_error",
+        "message": "list error"
+      }""",
+      500
+    )
+
+    assertFailsWith<GenericServerException> {
+      workos.fga.getResource("user", "user_123")
+    }
+  }
+
+  @Test
+  fun getResourceShouldReturnValidResourceAfterOneRetry() {
+    stubResponseWithScenario(
+      "/fga/v1/resources/user/user_123",
+      """{
+        "code": "internal_error",
+        "message": "list error"
+      }""",
+      500,
+      emptyMap(),
+      null,
+      null,
+      "Get resource",
+      STARTED,
+      "Error state"
+    )
+    stubResponseWithScenario(
+      "/fga/v1/resources/user/user_123",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123"
+      }""",
+      200,
+      emptyMap(),
+      null,
+      null,
+      "Get resource",
+      "Error state",
+      "Success state"
+    )
+
+    val resource = workos.fga.getResource("user", "user_123")
+
+    assertEquals(
+      Resource("user", "user_123"),
+      resource
+    )
+  }
+
+  @Test
+  fun getResourceShouldReturnValidResourceObjectWithMeta() {
+    stubResponse(
+      "/fga/v1/resources/user/user_123",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123",
+        "meta": {
+          "description": "Some user"
+        }
+      }"""
+    )
+
+    val resource = workos.fga.getResource("user", "user_123")
+
+    assertEquals(
+      Resource("user", "user_123", mapOf("description" to "Some user")),
+      resource
+    )
+  }
+
+  @Test
+  fun listResourcesShouldReturnValidResources() {
+    stubResponse(
+      "/fga/v1/resources",
+      """{
+        "data": [
+          {
+            "resource_type": "user",
+            "resource_id": "user_123"
+          },
+          {
+            "resource_type": "user",
+            "resource_id": "user_456",
+            "meta": {
+              "description": "Some user"
+            }
+          }
+        ],
+        "list_metadata": {
+          "after": "user_456",
+          "before": null
+        }
+      }"""
+    )
+
+    val resources = workos.fga.listResources(ListResourcesOptionsBuilder().build())
+
+    assertEquals(
+      Resource("user", "user_123"),
+      resources.data[0]
+    )
+    assertEquals(
+      Resource("user", "user_456", mapOf("description" to "Some user")),
+      resources.data[1]
+    )
+    assertEquals(
+      ListMetadata("user_456", null),
+      resources.listMetadata
+    )
+  }
+
+  @Test
+  fun listResourcesShouldReturnValidResourcesWithPaginationAndFilters() {
+    stubResponse(
+      "/fga/v1/resources",
+      """{
+        "data": [
+          {
+            "resource_type": "user",
+            "resource_id": "user_456"
+          }
+        ],
+        "list_metadata": {
+          "after": "user_456",
+          "before": null
+        }
+      }"""
+    )
+
+    val resources = workos.fga.listResources(
+      ListResourcesOptionsBuilder()
+        .order(Order.Asc)
+        .search("user_456")
+        .limit(5)
+        .build()
+    )
+
+    assertEquals(
+      Resource("user", "user_456"),
+      resources.data[0]
+    )
+    assertEquals(
+      ListMetadata("user_456", null),
+      resources.listMetadata
+    )
+  }
+
+  @Test
+  fun createResourceShouldReturnValidResourceObject() {
+    stubResponse(
+      "/fga/v1/resources",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123"
+      }"""
+    )
+
+    val options =
+      CreateResourceOptionsBuilder("user", "user_123")
+        .build()
+    val resource = workos.fga.createResource(options)
+
+    assertEquals(
+      Resource("user", "user_123"),
+      resource
+    )
+  }
+
+  @Test
+  fun createResourceShouldFailAfterMaxRetries() {
+    stubResponse(
+      "/fga/v1/resources",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123"
+      }""",
+      504
+    )
+
+    val options =
+      CreateResourceOptionsBuilder("user", "user_123")
+        .build()
+
+    assertFailsWith<GenericServerException> {
+      workos.fga.createResource(options)
+    }
+  }
+
+  @Test
+  fun createResourceShouldReturnValidResourceObjectAfterOneRetry() {
+    stubResponseWithScenario(
+      "/fga/v1/resources",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123"
+      }""",
+      502,
+      scenarioName = "Create resource",
+      scenarioState = STARTED,
+      nextScenarioState = "Error state"
+    )
+    stubResponseWithScenario(
+      "/fga/v1/resources",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123"
+      }""",
+      scenarioName = "Create resource",
+      scenarioState = "Error state",
+      nextScenarioState = "Success state"
+    )
+
+    val options =
+      CreateResourceOptionsBuilder("user", "user_123")
+        .build()
+    val resource = workos.fga.createResource(options)
+
+    assertEquals(
+      Resource("user", "user_123"),
+      resource
+    )
+  }
+
+  @Test
+  fun updateResourceShouldReturnValidResourceObject() {
+    stubResponse(
+      "/fga/v1/resources/user/user_123",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123",
+        "meta": {
+          "description": "Some user"
+        }
+      }""",
+      requestBody =
+      """{
+        "meta": {
+          "description": "Some user"
+        }
+      }"""
+    )
+
+    val options =
+      UpdateResourceOptionsBuilder()
+        .meta(mapOf("description" to "Some user"))
+        .build()
+
+    val resource = workos.fga.updateResource("user", "user_123", options)
+
+    assertEquals(
+      Resource("user", "user_123", mapOf("description" to "Some user")),
+      resource
+    )
+  }
+
+  @Test
+  fun updateResourceShouldFailAfterMaxRetries() {
+    stubResponse(
+      "/fga/v1/resources/user/user_123",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123",
+        "meta": {
+          "description": "Some user"
+        }
+      }""",
+      500,
+      requestBody =
+      """{
+        "meta": {
+          "description": "Some user"
+        }
+      }"""
+    )
+
+    val options =
+      UpdateResourceOptionsBuilder()
+        .meta(mapOf("description" to "Some user"))
+        .build()
+
+    assertFailsWith<GenericServerException> {
+      workos.fga.updateResource("user", "user_123", options)
+    }
+  }
+
+  @Test
+  fun updateResourceShouldReturnValidResourceObjectAfterOneRetry() {
+    stubResponseWithScenario(
+      "/fga/v1/resources/user/user_123",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123",
+        "meta": {
+          "description": "Some user"
+        }
+      }""",
+      responseStatus = 500,
+      requestBody =
+      """{
+        "meta": {
+          "description": "Some user"
+        }
+      }""",
+      scenarioName = "Update resource",
+      scenarioState = STARTED,
+      nextScenarioState = "Error state"
+    )
+    stubResponseWithScenario(
+      "/fga/v1/resources/user/user_123",
+      """{
+        "resource_type": "user",
+        "resource_id": "user_123",
+        "meta": {
+          "description": "Some user"
+        }
+      }""",
+      requestBody =
+      """{
+        "meta": {
+          "description": "Some user"
+        }
+      }""",
+      scenarioName = "Update resource",
+      scenarioState = "Error state",
+      nextScenarioState = "Success state"
+    )
+
+    val options =
+      UpdateResourceOptionsBuilder()
+        .meta(mapOf("description" to "Some user"))
+        .build()
+
+    val resource = workos.fga.updateResource("user", "user_123", options)
+
+    assertEquals(
+      Resource("user", "user_123", mapOf("description" to "Some user")),
+      resource
+    )
+  }
+
+  @Test
+  fun deleteResourceShouldWorkAndReturnNothing() {
+    stubResponse("/fga/v1/resources/user/user_123", "")
+
+    assertDoesNotThrow() { workos.fga.deleteResource("user", "user_123") }
+  }
+
+  @Test
+  fun deleteResourceShouldFailAfterMaxRetries() {
+    stubResponse("/fga/v1/resources/user/user_123", "", 500)
+
+    assertFailsWith<GenericServerException> {
+      workos.fga.deleteResource("user", "user_123")
+    }
+  }
+
+  @Test
+  fun deleteResourceShouldWorkAndReturnNothingAfterOneRetry() {
+    stubResponseWithScenario(
+      "/fga/v1/resources/user/user_123",
+      "",
+      500,
+      scenarioName = "Delete resource",
+      scenarioState = STARTED,
+      nextScenarioState = "Error state"
+    )
+    stubResponseWithScenario(
+      "/fga/v1/resources/user/user_123",
+      "",
+      scenarioName = "Delete resource",
+      scenarioState = "Error state",
+      nextScenarioState = "Success state"
+    )
+
+    assertFailsWith<GenericServerException> {
+      workos.fga.deleteResource("user", "user_123")
+    }
+  }
+
+  @Test
+  fun listWarrantsShouldReturnValidWarrants() {
+    stubResponse(
+      "/fga/v1/warrants",
+      """{
+        "data": [
+          {
+            "resource_type": "role",
+            "resource_id": "admin",
+            "relation": "member",
+            "subject": {
+              "resource_type": "user",
+              "resource_id": "tony-stark"
+            }
+          }
+        ],
+        "list_metadata": {
+          "after": "eyJpZCI6IntcInBrXCI6XCJ0mlyb25tZW50XzAxSjBLWF",
+          "before": null
+        }
+      }"""
+    )
+
+    val warrants = workos.fga.listWarrants(ListWarrantsOptionsBuilder().build())
+
+    assertEquals(
+      Warrant(
+        "role",
+        "admin",
+        "member",
+        Subject("user", "tony-stark")
+      ),
+      warrants.data[0]
+    )
+    assertEquals(ListMetadata("eyJpZCI6IntcInBrXCI6XCJ0mlyb25tZW50XzAxSjBLWF", null), warrants.listMetadata)
+  }
+
+  @Test
+  fun listWarrantsShouldReturnValidWarrantsWithPaginationAndFilters() {
+    stubResponse(
+      "/fga/v1/warrants",
+      """{
+        "data": [
+          {
+            "resource_type": "role",
+            "resource_id": "admin",
+            "relation": "member",
+            "subject": {
+              "resource_type": "user",
+              "resource_id": "tony-stark"
+            }
+          }
+        ],
+        "list_metadata": {
+          "after": "eyJpZCI6IntcInBrXCI6XCJ0mlyb25tZW50XzAxSjBLWF",
+          "before": null
+        }
+      }"""
+    )
+
+    val options = ListWarrantsOptionsBuilder()
+      .resourceType("role")
+      .resourceId("admin")
+      .relation("member")
+      .subjectType("user")
+      .subjectId("tony-stark")
+      .subjectRelation("member")
+      .limit(5)
+      .after("someAfterId")
+      .build()
+    val warrants = workos.fga.listWarrants(options)
+
+    assertEquals(
+      Warrant(
+        "role",
+        "admin",
+        "member",
+        Subject("user", "tony-stark")
+      ),
+      warrants.data[0]
+    )
+    assertEquals(ListMetadata("eyJpZCI6IntcInBrXCI6XCJ0mlyb25tZW50XzAxSjBLWF", null), warrants.listMetadata)
+  }
+
+  @Test
+  fun writeWarrantWithCreateOpShouldReturnWarrantResponse() {
+    stubResponse(
+      "/fga/v1/warrants",
+      """{
+        "warrant_token": "new_token"
+      }""",
+      requestBody=
+      """{
+        "op": "create",
+        "resource_type": "role",
+        "resource_id": "admin",
+        "relation": "member",
+        "subject": {
+          "resource_type": "user",
+          "resource_id": "tony-stark"
+        }
+      }"""
+    )
+
+    val options =
+      WriteWarrantOptionsBuilder("create", "role", "admin", "member", Subject("user", "tony-stark"))
+        .build()
+
+    val warrantResponse = workos.fga.writeWarrant(options)
+
+    assertEquals("new_token", warrantResponse.warrantToken)
+  }
+
+  @Test
+  fun writeWarrantWithDeleteOpShouldReturnWarrantResponse() {
+    stubResponse(
+      "/fga/v1/warrants",
+      """{
+        "warrant_token": "new_token"
+      }""",
+      requestBody=
+      """{
+        "op": "delete",
+        "resource_type": "role",
+        "resource_id": "admin",
+        "relation": "member",
+        "subject": {
+          "resource_type": "user",
+          "resource_id": "tony-stark"
+        }
+      }"""
+    )
+
+    val options =
+      WriteWarrantOptionsBuilder("delete", "role", "admin", "member", Subject("user", "tony-stark"))
+        .build()
+
+    val warrantResponse = workos.fga.writeWarrant(options)
+
+    assertEquals("new_token", warrantResponse.warrantToken)
+  }
+
+  @Test
+  fun batchWriteWarrantsShouldReturnWarrantResponse() {
+    stubResponse(
+      "/fga/v1/warrants",
+      """{
+        "warrant_token": "new_token"
+      }""",
+      requestBody=
+      """[
+        {
+          "op": "delete",
+          "resource_type": "role",
+          "resource_id": "editor",
+          "relation": "member",
+          "subject": {
+            "resource_type": "user",
+            "resource_id": "tony-stark"
+          }
+        },
+        {
+          "op": "create",
+          "resource_type": "role",
+          "resource_id": "admin",
+          "relation": "member",
+          "subject": {
+            "resource_type": "user",
+            "resource_id": "tony-stark"
+          }
+        }
+      ]"""
+    )
+
+    val options = listOf(
+      WriteWarrantOptionsBuilder("delete", "role", "editor", "member", Subject("user", "tony-stark")).build(),
+      WriteWarrantOptionsBuilder("create", "role", "admin", "member", Subject("user", "tony-stark")).build()
+    )
+
+    val warrantResponse = workos.fga.batchWriteWarrants(options)
+
+    assertEquals("new_token", warrantResponse.warrantToken)
+  }
+
+  @Test
+  fun checkShouldReturnValidCheckResponse() {
+    stubResponse(
+      "/fga/v1/check",
+      """{
+        "result": "authorized",
+        "is_implicit": false
+      }""",
+      requestBody=
+      """{
+        "checks": [
+          {
+            "resource_type": "role",
+            "resource_id": "admin",
+            "relation": "member",
+            "subject": {
+              "resource_type": "user",
+              "resource_id": "tony-stark"
+            },
+            "context": {
+              "role": "admin"
+            }
+          }
+        ]
+      }"""
+    )
+
+    val options = CheckOptionsBuilder(
+      listOf(
+        WarrantCheckOptions(
+          "role",
+          "admin",
+          "member",
+          Subject("user", "tony-stark"),
+          mapOf("role" to "admin")
+        )
+      )
+    ).build()
+
+    val checkResponse = workos.fga.check(options)
+
+    assertEquals(true, checkResponse.Authorized())
+    assertEquals(false, checkResponse.isImplicit)
+  }
+
+  @Test
+  fun checkWithDebugShouldReturnValidCheckResponse() {
+    stubResponse(
+      "/fga/v1/check",
+      """{
+        "result": "authorized",
+        "is_implicit": true,
+        "debug_info": {
+          "processing_time": 15665292,
+          "decision_tree": {
+            "check": {
+                "resource_type": "role",
+                "resource_id": "admin",
+                "relation": "member",
+                "subject": {
+                    "resource_type": "user",
+                    "resource_id": "tony-stark"
+                },
+                "context": null
+            },
+            "decision": "matched",
+            "processing_time": 6235333,
+            "children": [
+                {
+                    "check": {
+                        "resource_type": "role",
+                        "resource_id": "admin",
+                        "relation": "member",
+                        "subject": {
+                            "resource_type": "tenant",
+                            "resource_id": "stark-industries"
+                        },
+                        "context": null
+                    },
+                    "decision": "matched",
+                    "processing_time": 2757333,
+                    "children": [
+                        {
+                            "check": {
+                                "resource_type": "tenant",
+                                "resource_id": "stark-industries",
+                                "relation": "member",
+                                "subject": {
+                                    "resource_type": "user",
+                                    "resource_id": "tony-stark"
+                                },
+                                "context": null
+                            },
+                            "decision": "matched",
+                            "processing_time": 3421625,
+                            "children": null
+                        }
+                    ]
+                }
+            ]
+          }
+        }
+      }""",
+      requestBody=
+      """{
+        "checks": [
+          {
+            "resource_type": "role",
+            "resource_id": "admin",
+            "relation": "member",
+            "subject": {
+              "resource_type": "user",
+              "resource_id": "tony-stark"
+            },
+            "context": {
+              "role": "admin"
+            }
+          }
+        ],
+        "debug": true
+      }"""
+    )
+
+    val options = CheckOptionsBuilder(
+      listOf(
+        WarrantCheckOptions(
+          "role",
+          "admin",
+          "member",
+          Subject("user", "tony-stark"),
+          mapOf("role" to "admin")
+        )
+      ),
+      true
+    ).build()
+
+    val checkResponse = workos.fga.check(options)
+
+    assertEquals(true, checkResponse.Authorized())
+    assertEquals(true, checkResponse.isImplicit)
+    assertNotNull(checkResponse.debugInfo)
+    assertNotNull(checkResponse.debugInfo?.processingTime)
+    assertNotNull(checkResponse.debugInfo?.decisionTree)
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.check)
+    assertEquals("role", checkResponse.debugInfo?.decisionTree?.check?.resourceType)
+    assertEquals("admin", checkResponse.debugInfo?.decisionTree?.check?.resourceId)
+    assertEquals("member", checkResponse.debugInfo?.decisionTree?.check?.relation)
+    assertEquals("user", checkResponse.debugInfo?.decisionTree?.check?.subject?.resourceType)
+    assertEquals("tony-stark", checkResponse.debugInfo?.decisionTree?.check?.subject?.resourceId)
+    assertEquals("matched", checkResponse.debugInfo?.decisionTree?.decision)
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.processingTime)
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.children)
+    assertEquals(1, checkResponse.debugInfo?.decisionTree?.children?.size)
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.children?.get(0))
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.children?.get(0)?.check)
+    assertEquals("role", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.check?.resourceType)
+    assertEquals("admin", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.check?.resourceId)
+    assertEquals("member", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.check?.relation)
+    assertEquals("tenant", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.check?.subject?.resourceType)
+    assertEquals("stark-industries", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.check?.subject?.resourceId)
+    assertEquals("matched", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.decision)
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.children?.get(0)?.processingTime)
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children)
+    assertEquals(1, checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.size)
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0))
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check)
+    assertEquals("tenant", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.resourceType)
+    assertEquals("stark-industries", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.resourceId)
+    assertEquals("member", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.relation)
+    assertEquals("user", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.subject?.resourceType)
+    assertEquals("tony-stark", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.subject?.resourceId)
+    assertEquals("matched", checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.decision)
+    assertNotNull(checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.processingTime)
+    assertNull(checkResponse.debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.children)
+  }
+
+  @Test
+  fun checkBatchShouldReturnValidCheckResponses() {
+    stubResponse(
+      "/fga/v1/check",
+      """[
+        {
+          "result": "authorized",
+          "is_implicit": false
+        },
+        {
+          "result": "authorized",
+          "is_implicit": true
+        }
+      ]""",
+      requestBody=
+      """{
+        "op": "batch",
+        "checks": [
+          {
+            "resource_type": "role",
+            "resource_id": "admin",
+            "relation": "member",
+            "subject": {
+              "resource_type": "user",
+              "resource_id": "tony-stark"
+            }
+          },
+          {
+            "resource_type": "tenant",
+            "resource_id": "stark-industries",
+            "relation": "member",
+            "subject": {
+              "resource_type": "user",
+              "resource_id": "tony-stark"
+            }
+          }
+        ]
+      }"""
+    )
+
+    val options = CheckBatchOptionsBuilder(
+      listOf(
+        WarrantCheckOptions(
+            "role",
+            "admin",
+            "member",
+            Subject("user", "tony-stark")
+        ),
+        WarrantCheckOptions(
+            "tenant",
+            "stark-industries",
+            "member",
+            Subject("user", "tony-stark")
+        )
+      )
+    ).build()
+
+    val checkResponses = workos.fga.checkBatch(options)
+
+    assertEquals(true, checkResponses[0].Authorized())
+    assertEquals(false, checkResponses[0].isImplicit)
+    assertEquals(true, checkResponses[1].Authorized())
+    assertEquals(true, checkResponses[1].isImplicit)
+  }
+
+  @Test
+  fun checkBatchWithDebugShouldReturnValidCheckResponses() {
+    stubResponse(
+      "/fga/v1/check",
+      """[
+        {
+          "result": "authorized",
+          "is_implicit": true,
+          "debug_info": {
+            "processing_time": 17055584,
+            "decision_tree": {
+              "check": {
+                "resource_type": "role",
+                "resource_id": "admin",
+                "relation": "member",
+                "subject": {
+                  "resource_type": "user",
+                  "resource_id": "user1"
+                },
+                "context": null
+              },
+              "decision": "matched",
+              "processing_time": 7921500,
+              "children": [
+                {
+                  "check": {
+                    "resource_type": "role",
+                    "resource_id": "admin",
+                    "relation": "member",
+                    "subject": {
+                      "resource_type": "tenant",
+                      "resource_id": "stark-industries"
+                    },
+                    "context": null
+                  },
+                  "decision": "matched",
+                  "processing_time": 3444209,
+                  "children": [
+                    {
+                      "check": {
+                        "resource_type": "tenant",
+                        "resource_id": "stark-industries",
+                        "relation": "member",
+                        "subject": {
+                          "resource_type": "user",
+                          "resource_id": "tony-stark"
+                        },
+                        "context": null
+                      },
+                      "decision": "matched",
+                      "processing_time": 4361875,
+                      "children": null
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        },
+        {
+          "result": "authorized",
+          "is_implicit": false,
+          "debug_info": {
+            "processing_time": 8006583,
+            "decision_tree": {
+              "check": {
+                "resource_type": "tenant",
+                "resource_id": "stark-industries",
+                "relation": "member",
+                "subject": {
+                  "resource_type": "user",
+                  "resource_id": "tony-stark"
+                },
+                "context": null
+              },
+              "decision": "matched",
+              "processing_time": 6379750,
+              "children": null
+            }
+          }
+        }
+      ]""",
+      requestBody=
+      """{
+        "op": "batch",
+        "checks": [
+          {
+            "resource_type": "role",
+            "resource_id": "admin",
+            "relation": "member",
+            "subject": {
+              "resource_type": "user",
+              "resource_id": "tony-stark"
+            }
+          },
+          {
+            "resource_type": "tenant",
+            "resource_id": "stark-industries",
+            "relation": "member",
+            "subject": {
+              "resource_type": "user",
+              "resource_id": "tony-stark"
+            }
+          }
+        ]
+      }"""
+    )
+
+    val options = CheckBatchOptionsBuilder(
+      listOf(
+        WarrantCheckOptions(
+          "role",
+          "admin",
+          "member",
+          Subject("user", "tony-stark")
+        ),
+        WarrantCheckOptions(
+          "tenant",
+          "stark-industries",
+          "member",
+          Subject("user", "tony-stark")
+        )
+      )
+    ).build()
+
+    val checkResponses = workos.fga.checkBatch(options)
+
+    assertEquals(true, checkResponses[0].Authorized())
+    assertEquals(true, checkResponses[0].isImplicit)
+    assertNotNull(checkResponses[0].debugInfo)
+    assertNotNull(checkResponses[0].debugInfo?.processingTime)
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree)
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.check)
+    assertEquals("role", checkResponses[0].debugInfo?.decisionTree?.check?.resourceType)
+    assertEquals("admin", checkResponses[0].debugInfo?.decisionTree?.check?.resourceId)
+    assertEquals("member", checkResponses[0].debugInfo?.decisionTree?.check?.relation)
+    assertEquals("user", checkResponses[0].debugInfo?.decisionTree?.check?.subject?.resourceType)
+    assertEquals("user1", checkResponses[0].debugInfo?.decisionTree?.check?.subject?.resourceId)
+    assertNull(checkResponses[0].debugInfo?.decisionTree?.check?.context)
+    assertEquals("matched", checkResponses[0].debugInfo?.decisionTree?.decision)
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.processingTime)
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.children)
+    assertEquals(1, checkResponses[0].debugInfo?.decisionTree?.children?.size)
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0))
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.check)
+    assertEquals("role", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.check?.resourceType)
+    assertEquals("admin", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.check?.resourceId)
+    assertEquals("member", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.check?.relation)
+    assertEquals("tenant", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.check?.subject?.resourceType)
+    assertEquals("stark-industries", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.check?.subject?.resourceId)
+    assertNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.check?.context)
+    assertEquals("matched", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.decision)
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.processingTime)
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children)
+    assertEquals(1, checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.size)
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0))
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check)
+    assertEquals("tenant", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.resourceType)
+    assertEquals("stark-industries", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.resourceId)
+    assertEquals("member", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.relation)
+    assertEquals("user", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.subject?.resourceType)
+    assertEquals("tony-stark", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.subject?.resourceId)
+    assertNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.check?.context)
+    assertEquals("matched", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.decision)
+    assertNotNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.processingTime)
+    assertNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.children)
+    assertEquals(true, checkResponses[1].Authorized())
+    assertEquals(false, checkResponses[1].isImplicit)
+    assertNotNull(checkResponses[1].debugInfo)
+    assertEquals(8006583, checkResponses[1].debugInfo?.processingTime)
+    assertNotNull(checkResponses[1].debugInfo?.decisionTree)
+    assertNotNull(checkResponses[1].debugInfo?.decisionTree?.check)
+    assertEquals("tenant", checkResponses[1].debugInfo?.decisionTree?.check?.resourceType)
+    assertEquals("stark-industries", checkResponses[1].debugInfo?.decisionTree?.check?.resourceId)
+    assertEquals("member", checkResponses[1].debugInfo?.decisionTree?.check?.relation)
+    assertEquals("user", checkResponses[1].debugInfo?.decisionTree?.check?.subject?.resourceType)
+    assertEquals("tony-stark", checkResponses[1].debugInfo?.decisionTree?.check?.subject?.resourceId)
+    assertNull(checkResponses[1].debugInfo?.decisionTree?.check?.context)
+    assertEquals("matched", checkResponses[1].debugInfo?.decisionTree?.decision)
+    assertEquals(6379750, checkResponses[1].debugInfo?.decisionTree?.processingTime)
+    assertNull(checkResponses[1].debugInfo?.decisionTree?.children)
+  }
+
+  @Test
+  fun queryShouldReturnValidQueryResponse() {
+    stubResponse(
+      "/fga/v1/query",
+      """{
+        "data": [
+          {
+            "resource_type": "role",
+            "resource_id": "admin",
+            "relation": "member",
+            "warrant": {
+              "resource_type": "role",
+              "resource_id": "admin",
+              "relation": "member",
+              "subject": {
+                "resource_type": "user",
+                "resource_id": "tony-stark"
+              }
+            },
+            "is_implicit": false,
+            "meta": {
+              "description": "Admin role"
+            }
+          }
+        ],
+        "list_metadata": {
+          "before": null,
+          "after": null
+        }
+      }""",
+      requestBody =
+      """{
+        "q": "select role where user:tony-stark is member"
+      }"""
+    )
+
+    val options = QueryOptionsBuilder("select role where user:tony-stark is member").build()
+    val queryResponse = workos.fga.query(options)
+
+    assertEquals(1, queryResponse.data.size)
+    assertEquals("role", queryResponse.data[0].resourceType)
+    assertEquals("admin", queryResponse.data[0].resourceId)
+    assertEquals("member", queryResponse.data[0].relation)
+    assertEquals(Warrant("role", "admin", "member", Subject("user", "tony-stark")), queryResponse.data[0].warrant)
+    assertEquals(false, queryResponse.data[0].isImplicit)
+    assertNotNull(queryResponse.data[0].meta)
+    assertEquals("Admin role", queryResponse.data[0].meta?.get("description"))
+    assertNull(queryResponse.listMetadata.before)
+    assertNull(queryResponse.listMetadata.after)
+  }
+}

--- a/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
+++ b/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
@@ -417,7 +417,7 @@ class FgaApiTest : TestBase() {
       nextScenarioState = "Success state"
     )
 
-    assertFailsWith<GenericServerException> {
+    assertDoesNotThrow() {
       workos.fga.deleteResource("user", "user_123")
     }
   }


### PR DESCRIPTION
## Description

- Add support for FGA endpoints
    - `resources` (create/update/get/list/delete)
    - `warrants` (write/batch write/list)
    - `check` / `checkBatch`
    - `query`
- Adds retry support for http requests for FGA endpoints

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
