### PR TITLE
Warrant token support for listWarrants

### DIFF
--- a/src/main/kotlin/com/workos/fga/FgaApi.kt
+++ b/src/main/kotlin/com/workos/fga/FgaApi.kt
@@ -14,6 +14,7 @@ import com.workos.fga.types.CheckRequestOptions
 import com.workos.fga.types.CreateResourceOptions
 import com.workos.fga.types.ListResourcesOptions
 import com.workos.fga.types.ListWarrantsOptions
+import com.workos.fga.types.ListWarrantsRequestOptions
 import com.workos.fga.types.QueryOptions
 import com.workos.fga.types.QueryRequestOptions
 import com.workos.fga.types.UpdateResourceOptions
@@ -61,14 +62,21 @@ class FgaApi(private val workos: WorkOS) {
   }
 
   /** Get a list of all existing warrants matching the criteria specified */
-  fun listWarrants(options: ListWarrantsOptions? = null): Warrants {
+  fun listWarrants(options: ListWarrantsOptions? = null, requestOptions: ListWarrantsRequestOptions? = null): Warrants {
     val params: Map<String, String> =
       RequestConfig.toMap(options ?: ListWarrantsOptions()) as Map<String, String>
+
+    val config = RequestConfig.builder()
+      .params(params)
+
+    if (requestOptions != null) {
+      config.headers(mapOf("Warrant-Token" to requestOptions.warrantToken))
+    }
 
     return workos.get(
       "/fga/v1/warrants",
       Warrants::class.java,
-      RequestConfig.builder().params(params).build()
+      config.build()
     )
   }
 

--- a/src/main/kotlin/com/workos/fga/FgaApi.kt
+++ b/src/main/kotlin/com/workos/fga/FgaApi.kt
@@ -20,6 +20,14 @@ import com.workos.fga.types.QueryRequestOptions
 import com.workos.fga.types.UpdateResourceOptions
 import com.workos.fga.types.WriteWarrantOptions
 
+const val CHECK_RESULT_AUTHORIZED = "authorized"
+const val CHECK_RESULT_NOT_AUTHORIZED = "not_authorized"
+const val CHECK_OP_ALL_OF = "all_of"
+const val CHECK_OP_ANY_OF = "any_of"
+const val CHECK_OP_BATCH = "batch"
+const val WARRANT_OP_CREATE = "create"
+const val WARRANT_OP_DELETE = "delete"
+
 class FgaApi(private val workos: WorkOS) {
   /** Get an existing resource. */
   fun getResource(resourceType: String, resourceId: String): Resource {

--- a/src/main/kotlin/com/workos/fga/builders/CreateWarrantOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/CreateWarrantOptionsBuilder.kt
@@ -1,0 +1,48 @@
+package com.workos.fga.builders
+
+import com.workos.fga.models.Subject
+import com.workos.fga.types.CreateWarrantOptions
+
+/**
+ * Builder for options when performing a warrant create.
+ *
+ * @param resourceType The type of the resource. Must be one of your system's existing resource types.
+ * @param resourceId The unique ID of the resource.
+ * @param relation The relation for this resource to subject association. The relation must be valid per the resource type definition.
+ * @param subject (see [Subject]) The resource with the specified `relation` to the resource provided by resourceType and resourceId.
+ * @param policy A boolean expression that must evaluate to true for this warrant to apply. The expression can reference variables provided in the context attribute of access check requests.
+ */
+class CreateWarrantOptionsBuilder @JvmOverloads constructor(
+  private var resourceType: String,
+  private var resourceId: String,
+  private var relation: String,
+  private var subject: Subject,
+  private var policy: String? = null,
+) {
+  fun resourceType(value: String) = apply { resourceType = value }
+
+  fun resourceId(value: String) = apply { resourceId = value }
+
+  fun relation(value: String) = apply { relation = value }
+
+  fun subject(value: Subject) = apply { subject = value }
+
+  fun policy(value: String) = apply { policy = value }
+
+  fun build(): CreateWarrantOptions {
+    return CreateWarrantOptions(
+      resourceType = this.resourceType,
+      resourceId = this.resourceId,
+      relation = this.relation,
+      subject = this.subject,
+      policy = this.policy,
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(resourceType: String, resourceId: String, relation: String, subject: Subject): CreateWarrantOptionsBuilder {
+      return CreateWarrantOptionsBuilder(resourceType, resourceId, relation, subject)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/builders/DeleteWarrantOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/fga/builders/DeleteWarrantOptionsBuilder.kt
@@ -1,0 +1,48 @@
+package com.workos.fga.builders
+
+import com.workos.fga.models.Subject
+import com.workos.fga.types.DeleteWarrantOptions
+
+/**
+ * Builder for options when performing a warrant delete.
+ *
+ * @param resourceType The type of the resource. Must be one of your system's existing resource types.
+ * @param resourceId The unique ID of the resource.
+ * @param relation The relation for this resource to subject association. The relation must be valid per the resource type definition.
+ * @param subject (see [Subject]) The resource with the specified `relation` to the resource provided by resourceType and resourceId.
+ * @param policy A boolean expression that must evaluate to true for this warrant to apply. The expression can reference variables provided in the context attribute of access check requests.
+ */
+class DeleteWarrantOptionsBuilder @JvmOverloads constructor(
+  private var resourceType: String,
+  private var resourceId: String,
+  private var relation: String,
+  private var subject: Subject,
+  private var policy: String? = null,
+) {
+  fun resourceType(value: String) = apply { resourceType = value }
+
+  fun resourceId(value: String) = apply { resourceId = value }
+
+  fun relation(value: String) = apply { relation = value }
+
+  fun subject(value: Subject) = apply { subject = value }
+
+  fun policy(value: String) = apply { policy = value }
+
+  fun build(): DeleteWarrantOptions {
+    return DeleteWarrantOptions(
+      resourceType = this.resourceType,
+      resourceId = this.resourceId,
+      relation = this.relation,
+      subject = this.subject,
+      policy = this.policy,
+    )
+  }
+
+  companion object {
+    @JvmStatic
+    fun create(resourceType: String, resourceId: String, relation: String, subject: Subject): DeleteWarrantOptionsBuilder {
+      return DeleteWarrantOptionsBuilder(resourceType, resourceId, relation, subject)
+    }
+  }
+}

--- a/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
@@ -3,6 +3,7 @@ package com.workos.fga.models
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.fga.CHECK_RESULT_AUTHORIZED
 import com.workos.fga.types.WarrantCheckOptions
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -16,8 +17,8 @@ data class CheckResponse @JsonCreator constructor(
   @JsonProperty("debug_info")
   val debugInfo: DebugInfo? = null
 ) {
-    return this.result == "authorized"
   fun authorized(): Boolean {
+    return this.result == CHECK_RESULT_AUTHORIZED
   }
 }
 

--- a/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
@@ -16,8 +16,8 @@ data class CheckResponse @JsonCreator constructor(
   @JsonProperty("debug_info")
   val debugInfo: DebugInfo? = null
 ) {
-  fun Authorized(): Boolean {
     return this.result == "authorized"
+  fun authorized(): Boolean {
   }
 }
 

--- a/src/main/kotlin/com/workos/fga/types/CreateWarrantOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/CreateWarrantOptions.kt
@@ -2,6 +2,7 @@ package com.workos.fga.types
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.fga.WARRANT_OP_CREATE
 import com.workos.fga.models.Subject
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -35,4 +36,4 @@ class CreateWarrantOptions @JvmOverloads constructor(
    */
   @JsonProperty("policy")
   policy: String? = null,
-) : WriteWarrantOptions("create", resourceType, resourceId, relation, subject, policy)
+) : WriteWarrantOptions(WARRANT_OP_CREATE, resourceType, resourceId, relation, subject, policy)

--- a/src/main/kotlin/com/workos/fga/types/CreateWarrantOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/CreateWarrantOptions.kt
@@ -5,48 +5,34 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.workos.fga.models.Subject
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-open class WriteWarrantOptions @JvmOverloads constructor(
-  /**
-   * Operation to perform for the given warrant (create/delete).
-   */
-  @JsonProperty("op")
-  val op: String,
-
+class CreateWarrantOptions @JvmOverloads constructor(
   /**
    * The type of the resource.
    */
   @JsonProperty("resource_type")
-  val resourceType: String,
+  resourceType: String,
 
   /**
    * The unique ID of the resource.
    */
   @JsonProperty("resource_id")
-  val resourceId: String,
+  resourceId: String,
 
   /**
    * The relation for this resource to subject association. The relation must be valid per the resource type definition.
    */
   @JsonProperty("relation")
-  val relation: String,
+  relation: String,
 
   /**
    * The resource with the specified `relation` to the resource provided by resourceType and resourceId.
    */
   @JsonProperty("subject")
-  val subject: Subject,
+  subject: Subject,
 
   /**
    * A boolean expression that must evaluate to true for this warrant to apply. The expression can reference variables provided in the context attribute of access check requests.
    */
   @JsonProperty("policy")
-  val policy: String? = null,
-) {
-  init {
-    require(op.isNotBlank()) { "Op is required" }
-    require(resourceType.isNotBlank()) { "Resource type is required" }
-    require(resourceId.isNotBlank()) { "Resource id is required" }
-    require(relation.isNotBlank()) { "Relation is required" }
-    require(subject.resourceType.isNotBlank() && subject.resourceId.isNotBlank()) { "Subject is required" }
-  }
-}
+  policy: String? = null,
+) : WriteWarrantOptions("create", resourceType, resourceId, relation, subject, policy)

--- a/src/main/kotlin/com/workos/fga/types/DeleteWarrantOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/DeleteWarrantOptions.kt
@@ -2,6 +2,7 @@ package com.workos.fga.types
 
 import com.fasterxml.jackson.annotation.JsonInclude
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.fga.WARRANT_OP_DELETE
 import com.workos.fga.models.Subject
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
@@ -35,4 +36,4 @@ class DeleteWarrantOptions @JvmOverloads constructor(
    */
   @JsonProperty("policy")
   policy: String? = null,
-) : WriteWarrantOptions("delete", resourceType, resourceId, relation, subject, policy)
+) : WriteWarrantOptions(WARRANT_OP_DELETE, resourceType, resourceId, relation, subject, policy)

--- a/src/main/kotlin/com/workos/fga/types/DeleteWarrantOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/DeleteWarrantOptions.kt
@@ -5,48 +5,34 @@ import com.fasterxml.jackson.annotation.JsonProperty
 import com.workos.fga.models.Subject
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-open class WriteWarrantOptions @JvmOverloads constructor(
-  /**
-   * Operation to perform for the given warrant (create/delete).
-   */
-  @JsonProperty("op")
-  val op: String,
-
+class DeleteWarrantOptions @JvmOverloads constructor(
   /**
    * The type of the resource.
    */
   @JsonProperty("resource_type")
-  val resourceType: String,
+  resourceType: String,
 
   /**
    * The unique ID of the resource.
    */
   @JsonProperty("resource_id")
-  val resourceId: String,
+  resourceId: String,
 
   /**
    * The relation for this resource to subject association. The relation must be valid per the resource type definition.
    */
   @JsonProperty("relation")
-  val relation: String,
+  relation: String,
 
   /**
    * The resource with the specified `relation` to the resource provided by resourceType and resourceId.
    */
   @JsonProperty("subject")
-  val subject: Subject,
+  subject: Subject,
 
   /**
    * A boolean expression that must evaluate to true for this warrant to apply. The expression can reference variables provided in the context attribute of access check requests.
    */
   @JsonProperty("policy")
-  val policy: String? = null,
-) {
-  init {
-    require(op.isNotBlank()) { "Op is required" }
-    require(resourceType.isNotBlank()) { "Resource type is required" }
-    require(resourceId.isNotBlank()) { "Resource id is required" }
-    require(relation.isNotBlank()) { "Relation is required" }
-    require(subject.resourceType.isNotBlank() && subject.resourceId.isNotBlank()) { "Subject is required" }
-  }
-}
+  policy: String? = null,
+) : WriteWarrantOptions("delete", resourceType, resourceId, relation, subject, policy)

--- a/src/main/kotlin/com/workos/fga/types/ListWarrantsRequestOptions.kt
+++ b/src/main/kotlin/com/workos/fga/types/ListWarrantsRequestOptions.kt
@@ -1,0 +1,8 @@
+package com.workos.fga.types
+
+class ListWarrantsRequestOptions constructor(
+  /**
+   * A valid token string from a previous write operation or latest. This is used to specify the desired consistency for this read operation.
+   */
+  val warrantToken: String? = null,
+)

--- a/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
+++ b/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
@@ -7,6 +7,8 @@ import com.workos.common.models.Order
 import com.workos.fga.builders.CheckBatchOptionsBuilder
 import com.workos.fga.builders.CheckOptionsBuilder
 import com.workos.fga.builders.CreateResourceOptionsBuilder
+import com.workos.fga.builders.CreateWarrantOptionsBuilder
+import com.workos.fga.builders.DeleteWarrantOptionsBuilder
 import com.workos.fga.builders.ListResourcesOptionsBuilder
 import com.workos.fga.builders.ListWarrantsOptionsBuilder
 import com.workos.fga.builders.QueryOptionsBuilder
@@ -594,9 +596,29 @@ class FgaApiTest : TestBase() {
           }
         },
         {
+          "op": "delete",
+          "resource_type": "tenant",
+          "resource_id": "avengers",
+          "relation": "member",
+          "subject": {
+            "resource_type": "user",
+            "resource_id": "tony-stark"
+          }
+        },
+        {
           "op": "create",
           "resource_type": "role",
           "resource_id": "admin",
+          "relation": "member",
+          "subject": {
+            "resource_type": "user",
+            "resource_id": "tony-stark"
+          }
+        },
+        {
+          "op": "create",
+          "resource_type": "tenant",
+          "resource_id": "stark-industries",
           "relation": "member",
           "subject": {
             "resource_type": "user",
@@ -608,7 +630,9 @@ class FgaApiTest : TestBase() {
 
     val options = listOf(
       WriteWarrantOptionsBuilder("delete", "role", "editor", "member", Subject("user", "tony-stark")).build(),
-      WriteWarrantOptionsBuilder("create", "role", "admin", "member", Subject("user", "tony-stark")).build()
+      DeleteWarrantOptionsBuilder("tenant", "avengers", "member", Subject("user", "tony-stark")).build(),
+      WriteWarrantOptionsBuilder("create", "role", "admin", "member", Subject("user", "tony-stark")).build(),
+      CreateWarrantOptionsBuilder("tenant", "stark-industries", "member", Subject("user", "tony-stark")).build()
     )
 
     val warrantResponse = workos.fga.batchWriteWarrants(options)

--- a/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
+++ b/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
@@ -681,7 +681,7 @@ class FgaApiTest : TestBase() {
 
     val checkResponse = workos.fga.check(options)
 
-    assertEquals(true, checkResponse.Authorized())
+    assertEquals(true, checkResponse.authorized())
     assertEquals(false, checkResponse.isImplicit)
   }
 
@@ -728,7 +728,7 @@ class FgaApiTest : TestBase() {
 
     val checkResponse = workos.fga.check(options, requestOptions)
 
-    assertEquals(true, checkResponse.Authorized())
+    assertEquals(true, checkResponse.authorized())
     assertEquals(false, checkResponse.isImplicit)
   }
 
@@ -825,7 +825,7 @@ class FgaApiTest : TestBase() {
 
     val checkResponse = workos.fga.check(options)
 
-    assertEquals(true, checkResponse.Authorized())
+    assertEquals(true, checkResponse.authorized())
     assertEquals(true, checkResponse.isImplicit)
     assertNotNull(checkResponse.debugInfo)
     assertNotNull(checkResponse.debugInfo?.processingTime)
@@ -922,9 +922,9 @@ class FgaApiTest : TestBase() {
 
     val checkResponses = workos.fga.checkBatch(options)
 
-    assertEquals(true, checkResponses[0].Authorized())
+    assertEquals(true, checkResponses[0].authorized())
     assertEquals(false, checkResponses[0].isImplicit)
-    assertEquals(true, checkResponses[1].Authorized())
+    assertEquals(true, checkResponses[1].authorized())
     assertEquals(true, checkResponses[1].isImplicit)
   }
 
@@ -989,9 +989,9 @@ class FgaApiTest : TestBase() {
 
     val checkResponses = workos.fga.checkBatch(options, requestOptions)
 
-    assertEquals(true, checkResponses[0].Authorized())
+    assertEquals(true, checkResponses[0].authorized())
     assertEquals(false, checkResponses[0].isImplicit)
-    assertEquals(true, checkResponses[1].Authorized())
+    assertEquals(true, checkResponses[1].authorized())
     assertEquals(true, checkResponses[1].isImplicit)
   }
 
@@ -1122,7 +1122,7 @@ class FgaApiTest : TestBase() {
 
     val checkResponses = workos.fga.checkBatch(options)
 
-    assertEquals(true, checkResponses[0].Authorized())
+    assertEquals(true, checkResponses[0].authorized())
     assertEquals(true, checkResponses[0].isImplicit)
     assertNotNull(checkResponses[0].debugInfo)
     assertNotNull(checkResponses[0].debugInfo?.processingTime)
@@ -1161,7 +1161,7 @@ class FgaApiTest : TestBase() {
     assertEquals("matched", checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.decision)
     assertNotNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.processingTime)
     assertNull(checkResponses[0].debugInfo?.decisionTree?.children?.get(0)?.children?.get(0)?.children)
-    assertEquals(true, checkResponses[1].Authorized())
+    assertEquals(true, checkResponses[1].authorized())
     assertEquals(false, checkResponses[1].isImplicit)
     assertNotNull(checkResponses[1].debugInfo)
     assertEquals(8006583, checkResponses[1].debugInfo?.processingTime)


### PR DESCRIPTION
## Description

- Adds `ListWarrantsRequestOptions` to `listWarrants`
- Creates `CreateWarrantOptions` and `DeleteWarrantOptions` (with builders) for warrant writes
- Creates FGA constants for check results, check ops and warrant ops

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
