### PR TITLE
Update fga query method to make a GET request

### DIFF
--- a/src/main/kotlin/com/workos/fga/FgaApi.kt
+++ b/src/main/kotlin/com/workos/fga/FgaApi.kt
@@ -142,7 +142,7 @@ class FgaApi(private val workos: WorkOS) {
         it.key
       }
     }
-    
+
     val config = RequestConfig.builder()
       .params(params)
 

--- a/src/main/kotlin/com/workos/fga/FgaApi.kt
+++ b/src/main/kotlin/com/workos/fga/FgaApi.kt
@@ -132,13 +132,24 @@ class FgaApi(private val workos: WorkOS) {
 
   /** Perform a query in the current environment */
   fun query(options: QueryOptions, requestOptions: QueryRequestOptions? = null): QueryResponse {
+    var params: Map<String, String> =
+      RequestConfig.toMap(options) as Map<String, String>
+
+    params = params.mapKeys {
+      if (it.key == "query") {
+        "q"
+      } else {
+        it.key
+      }
+    }
+    
     val config = RequestConfig.builder()
-      .data(options)
+      .params(params)
 
     if (requestOptions != null) {
       config.headers(mapOf("Warrant-Token" to requestOptions.warrantToken))
     }
 
-    return workos.post("/fga/v1/query", QueryResponse::class.java, config.build())
+    return workos.get("/fga/v1/query", QueryResponse::class.java, config.build())
   }
 }

--- a/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
+++ b/src/test/kotlin/com/workos/test/fga/FgaApiTest.kt
@@ -1,5 +1,6 @@
 package com.workos.test.fga
 
+import com.github.tomakehurst.wiremock.client.WireMock.equalTo
 import com.github.tomakehurst.wiremock.stubbing.Scenario.STARTED
 import com.workos.common.exceptions.GenericServerException
 import com.workos.common.models.ListMetadata
@@ -1182,7 +1183,8 @@ class FgaApiTest : TestBase() {
   fun queryShouldReturnValidQueryResponse() {
     stubResponse(
       "/fga/v1/query",
-      """{
+      params = mapOf("q" to equalTo("select role where user:tony-stark is member")),
+      responseBody = """{
         "data": [
           {
             "resource_type": "role",
@@ -1208,10 +1210,6 @@ class FgaApiTest : TestBase() {
           "after": null
         }
       }""",
-      requestBody =
-      """{
-        "q": "select role where user:tony-stark is member"
-      }"""
     )
 
     val options = QueryOptionsBuilder("select role where user:tony-stark is member").build()
@@ -1232,8 +1230,9 @@ class FgaApiTest : TestBase() {
   @Test
   fun queryWithRequestOptsShouldReturnValidQueryResponse() {
     stubResponse(
-      "/fga/v1/query",
-      """{
+      url = "/fga/v1/query",
+      params = mapOf("q" to equalTo("select role where user:tony-stark is member")),
+      responseBody = """{
         "data": [
           {
             "resource_type": "role",
@@ -1258,10 +1257,6 @@ class FgaApiTest : TestBase() {
           "before": null,
           "after": null
         }
-      }""",
-      requestBody =
-      """{
-        "q": "select role where user:tony-stark is member"
       }""",
       requestHeaders = mapOf("Warrant-Token" to "my-token")
     )


### PR DESCRIPTION
## Description

- Fixes an issue with the FGA `query` method by making a GET request with query params to `/fga/v1/query`

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
