### PR TITLE
Add `role` to directory user

### DIFF
--- a/src/main/kotlin/com/workos/directorysync/models/DirectoryUserRole.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/DirectoryUserRole.kt
@@ -1,0 +1,5 @@
+package com.workos.directorysync.models
+
+import com.workos.common.models.Role
+
+typealias DirectoryUserRole = Role

--- a/src/main/kotlin/com/workos/directorysync/models/User.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/User.kt
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param emails The emails of the user.
  * @param groups The groups that the user is a member of.
  * @param state The state of the user.
+ * @param role The user's role based on group memberships.
  * @param customAttributes An object containing the custom attribute mapping for the Directory Provider.
  * @param rawAttributes An object containing the data returned from the Directory Provider.
  */
@@ -75,6 +76,10 @@ open class User
 
   @JvmField
   open val state: UserState,
+
+  @JvmField
+  @JsonProperty("role")
+  val role: DirectoryUserRole,
 
   @JvmField
   @JsonProperty("custom_attributes")

--- a/src/main/kotlin/com/workos/webhooks/models/UserUpdated.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/UserUpdated.kt
@@ -2,6 +2,7 @@ package com.workos.webhooks.models
 
 import com.fasterxml.jackson.annotation.JsonCreator
 import com.fasterxml.jackson.annotation.JsonProperty
+import com.workos.directorysync.models.DirectoryUserRole
 import com.workos.directorysync.models.Email
 import com.workos.directorysync.models.UserState
 
@@ -66,6 +67,10 @@ open class UserUpdated
   @JvmField
   @JsonProperty("raw_attributes")
   val rawAttributes: Map<String, Any?>,
+
+  @JvmField
+  @JsonProperty("role")
+  val role: DirectoryUserRole,
 
   /**
    * Object containing the names and values of attributes and their previous values.

--- a/src/test/kotlin/com/workos/test/directorysync/DirectorySyncApiTest.kt
+++ b/src/test/kotlin/com/workos/test/directorysync/DirectorySyncApiTest.kt
@@ -312,6 +312,7 @@ class DirectorySyncApiTest : TestBase() {
           "raw_attributes": {}
         }],
         "state": "active",
+        "role":{"slug":"admin"},
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:08:33.155Z",
         "custom_attributes": {
@@ -528,6 +529,7 @@ class DirectorySyncApiTest : TestBase() {
               "raw_attributes": {}
             }],
             "state": "active",
+            "role":{"slug":"admin"},
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:08:33.155Z",
             "custom_attributes": {
@@ -559,6 +561,7 @@ class DirectorySyncApiTest : TestBase() {
               "raw_attributes": {}
             }],
             "state": "active",
+            "role":{"slug":"member"},
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:08:33.155Z",
             "custom_attributes": {
@@ -629,6 +632,7 @@ class DirectorySyncApiTest : TestBase() {
               "raw_attributes": {}
             }],
             "state": "active",
+            "role":{"slug":"admin"},
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:08:33.155Z",
             "custom_attributes": {
@@ -659,6 +663,7 @@ class DirectorySyncApiTest : TestBase() {
               "raw_attributes": {}
             }],
             "state": "active",
+            "role":{"slug":"member"},
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:08:33.155Z",
             "custom_attributes": {
@@ -734,6 +739,7 @@ class DirectorySyncApiTest : TestBase() {
             "state": "active",
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:08:33.155Z",
+            "role":{"slug":"admin"},
             "custom_attributes": {
               "department": "Engineering"
             },
@@ -765,6 +771,7 @@ class DirectorySyncApiTest : TestBase() {
             "state": "active",
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:08:33.155Z",
+            "role":{"slug":"member"},
             "custom_attributes": {
               "department": "Engineering"
             },

--- a/src/test/kotlin/com/workos/test/directorysync/UserTest.kt
+++ b/src/test/kotlin/com/workos/test/directorysync/UserTest.kt
@@ -41,6 +41,7 @@ class UserTest : TestBase() {
           "raw_attributes": {}
         }],
         "state": "active",
+        "role":{"slug":"admin"},
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:08:33.155Z",
         "custom_attributes": {

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryGroupWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryGroupWebhookTests.kt
@@ -66,6 +66,7 @@ class DirectoryGroupWebhookTests : TestBase() {
           "first_name": "Michael",
           "job_title": "Software Engineer",
           "directory_id": "$directoryId",
+          "role": { "slug": "member" },
           "created_at": "2021-06-25T19:07:33.155Z",
           "updated_at": "2021-06-25T19:08:33.155Z",
           "raw_attributes": {

--- a/src/test/kotlin/com/workos/test/webhooks/DirectoryUserWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/DirectoryUserWebhookTests.kt
@@ -37,6 +37,7 @@ class DirectoryUserWebhookTests : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:08:33.155Z",
         "directory_id": "$directoryId",
+        "role": { "slug": "member" },
         "raw_attributes": {
           "id": "105777651754615852813",
           "etag": "\"nqbsbhvoIENh0WbZEZYWTG7mnk2phHz4rrCEo-rHT2k/E5jQHrdS88NS4ACUhZ4m9CYVR30\"",
@@ -102,6 +103,7 @@ class DirectoryUserWebhookTests : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:08:33.155Z",
         "directory_id": "$directoryId",
+        "role": { "slug": "admin" },
         "raw_attributes": {
           "id": "105777651754615852813",
           "etag": "\"nqbsbhvoIENh0WbZEZYWTG7mnk2phHz4rrCEo-rHT2k/E5jQHrdS88NS4ACUhZ4m9CYVR30\"",
@@ -140,6 +142,7 @@ class DirectoryUserWebhookTests : TestBase() {
         },
         "custom_attributes": {},
         "previous_attributes": {
+        "role": { "slug": "member" },
           "raw_attributes": {
             "emails": [
               {

--- a/src/test/kotlin/com/workos/test/webhooks/WebhooksApiTest.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/WebhooksApiTest.kt
@@ -38,6 +38,7 @@ class WebhooksApiTest : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:08:33.155Z",
         "directory_id": "directory_01F9M7F68PZP8QXP8G7X5QRHS7",
+        "role": { "slug": "member" },
         "custom_attributes": {},
         "raw_attributes": {
           "name": {
@@ -95,6 +96,7 @@ class WebhooksApiTest : TestBase() {
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:08:33.155Z",
         "directory_id": "directory_01F9M7F68PZP8QXP8G7X5QRHS7",
+        "role": { "slug": "member" },
         "custom_attributes": {},
         "raw_attributes": {},
         "new_unknown_property": {},


### PR DESCRIPTION
## Description

Add `role` to directory user model.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
