### PR TITLE
Make `role` attribute optional on `directorysync.models.User`

### DIFF
--- a/src/main/kotlin/com/workos/directorysync/models/User.kt
+++ b/src/main/kotlin/com/workos/directorysync/models/User.kt
@@ -79,7 +79,7 @@ open class User
 
   @JvmField
   @JsonProperty("role")
-  val role: DirectoryUserRole,
+  val role: DirectoryUserRole?,
 
   @JvmField
   @JsonProperty("custom_attributes")


### PR DESCRIPTION
## Description

This PR makes the `role` attribute optional on `directorysync.models.User` model.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
