### PR TITLE
Add GET /organization/:orgId/roles support

### DIFF
--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -10,7 +10,6 @@ import com.workos.common.models.Order
 import com.workos.organizations.models.Organization
 import com.workos.organizations.models.OrganizationList
 import com.workos.organizations.types.OrganizationDomainDataOptions
-import com.workos.roles.models.Role
 import com.workos.roles.models.RoleList
 
 /**
@@ -306,6 +305,6 @@ class OrganizationsApi(private val workos: WorkOS) {
    * Retrieve a list of roles for the given organization.
    */
   fun listOrganizationRoles(organizationId: String): RoleList {
-    return workos.get("/organizations/${organizationId}/roles", RoleList::class.java)
+    return workos.get("/organizations/$organizationId/roles", RoleList::class.java)
   }
 }

--- a/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
+++ b/src/main/kotlin/com/workos/organizations/OrganizationsApi.kt
@@ -10,6 +10,8 @@ import com.workos.common.models.Order
 import com.workos.organizations.models.Organization
 import com.workos.organizations.models.OrganizationList
 import com.workos.organizations.types.OrganizationDomainDataOptions
+import com.workos.roles.models.Role
+import com.workos.roles.models.RoleList
 
 /**
  * The OrganizationsApi provides convenience methods for working with WorkOS Organizations.
@@ -298,5 +300,12 @@ class OrganizationsApi(private val workos: WorkOS) {
       .build()
 
     return workos.put("/organizations/$id", Organization::class.java, config)
+  }
+
+  /**
+   * Retrieve a list of roles for the given organization.
+   */
+  fun listOrganizationRoles(organizationId: String): RoleList {
+    return workos.get("/organizations/${organizationId}/roles", RoleList::class.java)
   }
 }

--- a/src/main/kotlin/com/workos/roles/models/Role.kt
+++ b/src/main/kotlin/com/workos/roles/models/Role.kt
@@ -1,0 +1,47 @@
+package com.workos.roles.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * Represents a WorkOS Organization resource. This class is not meant to be
+ * instantiated directly.
+ *
+ * @param obj The unique object identifier type of the record.
+ * @param id The unique identifier for the Role.
+ * @param name The name of the Role.
+ * @param slug The slug of the Role.
+ * @param description The description of the Role.
+ * @param type The type of the Role.
+ * @param createdAt The timestamp of when the Role was created.
+ * @param updatedAt The timestamp of when the Role was updated.
+ */
+data class Role
+@JsonCreator constructor(
+  @JvmField
+  @JsonProperty("object")
+  val obj: String = "role",
+
+  @JvmField
+  val id: String,
+
+  @JvmField
+  val name: String,
+
+  @JvmField
+  val slug: String,
+
+  @JvmField
+  val description: String? = null,
+
+  @JvmField
+  val type: RoleType,
+
+  @JvmField
+  @JsonProperty("created_at")
+  val createdAt: String,
+
+  @JvmField
+  @JsonProperty("updated_at")
+  val updatedAt: String
+)

--- a/src/main/kotlin/com/workos/roles/models/RoleList.kt
+++ b/src/main/kotlin/com/workos/roles/models/RoleList.kt
@@ -1,7 +1,6 @@
 package com.workos.roles.models
 
 import com.fasterxml.jackson.annotation.JsonCreator
-import com.fasterxml.jackson.annotation.JsonProperty
 
 /**
  * A list of WorkOS [Role] resources. This class is not meant to be

--- a/src/main/kotlin/com/workos/roles/models/RoleList.kt
+++ b/src/main/kotlin/com/workos/roles/models/RoleList.kt
@@ -1,0 +1,16 @@
+package com.workos.roles.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * A list of WorkOS [Role] resources. This class is not meant to be
+ * instantiated directly.
+ *
+ * @param data A list of [Role].
+ */
+data class RoleList
+@JsonCreator constructor(
+  @JvmField
+  val data: List<Role>,
+)

--- a/src/main/kotlin/com/workos/roles/models/RoleType.kt
+++ b/src/main/kotlin/com/workos/roles/models/RoleType.kt
@@ -1,0 +1,13 @@
+package com.workos.roles.models
+
+import com.fasterxml.jackson.annotation.JsonValue
+
+/**
+ * An enumeration of types of [Role]
+ *
+ * @param state The Role type string value.
+ */
+enum class RoleType(@JsonValue val state: String) {
+  Environment("EnvironmentRole"),
+  Organization("OrganizationRole")
+}

--- a/src/main/kotlin/com/workos/roles/models/RoleType.kt
+++ b/src/main/kotlin/com/workos/roles/models/RoleType.kt
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.annotation.JsonValue
 /**
  * An enumeration of types of [Role]
  *
- * @param state The Role type string value.
+ * @param type The Role type string value.
  */
-enum class RoleType(@JsonValue val state: String) {
+enum class RoleType(@JsonValue val type: String) {
   Environment("EnvironmentRole"),
   Organization("OrganizationRole")
 }

--- a/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
+++ b/src/test/kotlin/com/workos/test/organizations/OrganizationsApiTest.kt
@@ -582,4 +582,56 @@ class OrganizationsApiTest : TestBase() {
     assertEquals(data["organizationDomainName"], organization.name)
     assertEquals(data["organizationDomainId"], organization.domains[0].id)
   }
+
+  @Test
+  fun listOrganizationRolesShouldReturnPayload() {
+    val workos = createWorkOSClient()
+
+    val organizationId = "org_01FJYCNTB6VC4K5R8BTF86286Q"
+
+    stubResponse(
+      "/organizations/$organizationId/roles",
+      """{
+        "object": "list",
+        "data": [
+          {
+            "object": "role",
+            "id": "role_01EHQMYV6MBK39QC5PZXHY59C5",
+            "name": "Admin",
+            "slug": "admin",
+            "description": null,
+            "type": "EnvironmentRole",
+            "created_at": "2024-01-01T00:00:00.000Z",
+            "updated_at": "2024-01-01T00:00:00.000Z"
+          },
+          {
+            "object": "role",
+            "id": "role_01EHQMYV6MBK39QC5PZXHY59C3",
+            "name": "Member",
+            "slug": "member",
+            "description": null,
+            "type": "EnvironmentRole",
+            "created_at": "2024-01-01T00:00:00.000Z",
+            "updated_at": "2024-01-01T00:00:00.000Z"
+          },
+          {
+            "object": "role",
+            "id": "role_01EHQMYV6MBK39QC5PZXHY59C3",
+            "name": "OrganizationMember",
+            "slug": "org-member",
+            "description": null,
+            "type": "OrganizationRole",
+            "created_at": "2024-01-01T00:00:00.000Z",
+            "updated_at": "2024-01-01T00:00:00.000Z"
+          }
+        ]
+      }"""
+    )
+
+    val (roles) = workos.organizations.listOrganizationRoles(organizationId)
+
+    assertEquals("role_01EHQMYV6MBK39QC5PZXHY59C5", roles.get(0).id)
+    assertEquals("Admin", roles.get(0).name)
+    assertEquals("admin", roles.get(0).slug)
+  }
 }


### PR DESCRIPTION
## Description
Add GET /organization/:orgId/roles support.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
