### PR TITLE
Add optional `returnTo` parameter to `getLogoutUrl`

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
+++ b/src/main/kotlin/com/workos/usermanagement/UserManagementApi.kt
@@ -466,10 +466,13 @@ class UserManagementApi(private val workos: WorkOS) {
   }
 
   /** End a user's session. The user's browser should be redirected to this URL. */
-  fun getLogoutUrl(sessionId: String): String {
+  fun getLogoutUrl(sessionId: String, returnTo: String? = null): String {
     return URIBuilder(workos.baseUrl)
       .setPath("/user_management/sessions/logout")
-      .addParameter("session_id", sessionId)
+      .apply {
+        addParameter("session_id", sessionId)
+        returnTo?.let { addParameter("return_to", it) }
+      }
       .toString()
   }
 }

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -1622,4 +1622,14 @@ class UserManagementApiTest : TestBase() {
       url
     )
   }
+
+  @Test
+  fun getLogoutUrlWithReturnToShouldReturnValidUrlResponse() {
+    val url = workos.userManagement.getLogoutUrl("session_123", returnTo = "https://your-app.com")
+
+    assertEquals(
+      "http://localhost:${getWireMockPort()}/user_management/sessions/logout?session_id=session_123&return_to=https%3A%2F%2Fyour-app.com",
+      url
+    )
+  }
 }


### PR DESCRIPTION
## Description

Adds a new optional `returnTo` parameter to the `getLogoutUrl` method to support the upcoming Logout URIs feature.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
