### PR TITLE
add lastSignInAt to user

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/models/User.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/User.kt
@@ -12,6 +12,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param lastName The last name of the user.
  * @param emailVerified Whether the user’s email has been verified.
  * @param profilePictureUrl A URL reference to an image representing the user.
+ * @param lastSignInAt The timestamp when the user last signed in.
  * @param createdAt The timestamp when the user was created.
  * @param updatedAt The timestamp when the user was last updated.
  */
@@ -33,6 +34,9 @@ data class User @JsonCreator constructor(
 
   @JsonProperty("profile_picture_url")
   val profilePictureUrl: String? = null,
+
+  @JsonProperty("last_sign_in_at")
+  val lastSignInAt: String? = null,
 
   @JsonProperty("created_at")
   val createdAt: String,

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -51,6 +51,7 @@ class UserManagementApiTest : TestBase() {
         "profile_picture_url": "https://example.com/profile_picture.jpg",
         "first_name": "Test",
         "last_name": "User",
+        "last_sign_in_at": "2021-06-25T19:07:33.155Z",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }"""
@@ -66,6 +67,7 @@ class UserManagementApiTest : TestBase() {
         "User",
         true,
         "https://example.com/profile_picture.jpg",
+        "2021-06-25T19:07:33.155Z"
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),
@@ -83,6 +85,7 @@ class UserManagementApiTest : TestBase() {
             "object": "user",
             "id": "user_123",
             "email": "test01@example.com",
+            "last_sign_in_at": "2021-06-25T19:07:33.155Z",
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:07:33.155Z"
           }
@@ -105,6 +108,7 @@ class UserManagementApiTest : TestBase() {
         false,
         null,
         "2021-06-25T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),
       users.data[0]
@@ -122,6 +126,7 @@ class UserManagementApiTest : TestBase() {
             "object": "user",
             "id": "user_123",
             "email": "test01@example.com",
+            "last_sign_in_at": "2021-06-25T19:07:33.155Z",
             "created_at": "2021-06-25T19:07:33.155Z",
             "updated_at": "2021-06-25T19:07:33.155Z"
           }
@@ -154,6 +159,7 @@ class UserManagementApiTest : TestBase() {
         false,
         null,
         "2021-06-25T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),
       users.data[0]
@@ -173,6 +179,7 @@ class UserManagementApiTest : TestBase() {
         "profile_picture_url": null,
         "first_name": "Test",
         "last_name": "User",
+        "last_sign_in_at": "2021-06-25T19:07:33.155Z",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
@@ -205,6 +212,7 @@ class UserManagementApiTest : TestBase() {
         true,
         null,
         "2021-06-25T19:07:33.155Z",
+        "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),
       user
@@ -223,6 +231,7 @@ class UserManagementApiTest : TestBase() {
         "profile_picture_url": null,
         "first_name": "Test",
         "last_name": "User",
+        "last_sign_in_at": "2021-06-25T19:07:33.155Z",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
@@ -254,6 +263,7 @@ class UserManagementApiTest : TestBase() {
         "User",
         true,
         null,
+        "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),
@@ -1000,6 +1010,7 @@ class UserManagementApiTest : TestBase() {
         "profile_picture_url": null,
         "first_name": "Test",
         "last_name": "User",
+        "last_sign_in_at": "2021-06-25T19:07:33.155Z",
         "created_at": "2021-06-25T19:07:33.155Z",
         "updated_at": "2021-06-25T19:07:33.155Z"
       }""",
@@ -1020,6 +1031,7 @@ class UserManagementApiTest : TestBase() {
         "User",
         true,
         null,
+        "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),

--- a/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
+++ b/src/test/kotlin/com/workos/test/user_management/UserManagementApiTest.kt
@@ -67,7 +67,7 @@ class UserManagementApiTest : TestBase() {
         "User",
         true,
         "https://example.com/profile_picture.jpg",
-        "2021-06-25T19:07:33.155Z"
+        "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z",
         "2021-06-25T19:07:33.155Z"
       ),


### PR DESCRIPTION
## Description
https://linear.app/workos/issue/AUTH-4181/update-workos-kotlin-sdk-for-last-sign-in-at

adds `lastSignInAt` to user

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```
If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.

docs PR: https://github.com/workos/workos/pull/35170
