### PR TITLE
add password_reset.succeeded event type

### DIFF
--- a/src/main/kotlin/com/workos/webhooks/models/EventType.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/EventType.kt
@@ -164,5 +164,10 @@ enum class EventType(
   /**
    * Triggers when a user requests to reset their password.
    */
-  PasswordResetCreated("password_reset.created")
+  PasswordResetCreated("password_reset.created"),
+
+  /**
+   * Triggers when a user successfully resets their password.
+   */
+  PasswordResetSucceeded("password_reset.succeeded")
 }

--- a/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
+++ b/src/main/kotlin/com/workos/webhooks/models/WebhookJsonDeserializer.kt
@@ -71,6 +71,7 @@ class WebhookJsonDeserializer : JsonDeserializer<WebhookEvent>() {
       EventType.OrganizationMembershipDeleted -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.OrganizationMembershipUpdated -> OrganizationMembershipEvent(id, eventType, deserializeData(data, OrganizationMembership::class.java), createdAt)
       EventType.PasswordResetCreated -> PasswordResetEvent(id, eventType, deserializeData(data, PasswordResetEventData::class.java), createdAt)
+      EventType.PasswordResetSucceeded -> PasswordResetEvent(id, eventType, deserializeData(data, PasswordResetEventData::class.java), createdAt)
     }
   }
 

--- a/src/test/kotlin/com/workos/test/webhooks/PasswordResetWebhookTests.kt
+++ b/src/test/kotlin/com/workos/test/webhooks/PasswordResetWebhookTests.kt
@@ -46,4 +46,20 @@ class PasswordResetWebhookTests : TestBase() {
     assertEquals(webhook.id, webhookId)
     assertEquals((webhook as PasswordResetEvent).data.id, passwordResetId)
   }
+
+  fun constructPasswordResetSucceededEvent() {
+    val workos = createWorkOSClient()
+    val webhookData = generateWebhookEvent(EventType.PasswordResetSucceeded)
+    val testData = WebhooksApiTest.prepareTest(webhookData)
+
+    val webhook = workos.webhooks.constructEvent(
+      webhookData,
+      testData["signature"] as String,
+      testData["secret"] as String
+    )
+
+    assertTrue(webhook is PasswordResetEvent)
+    assertEquals(webhook.id, webhookId)
+    assertEquals((webhook as PasswordResetEvent).data.id, passwordResetId)
+  }
 }


### PR DESCRIPTION
## Description
https://linear.app/workos/issue/AUTH-4443/add-password-resetsucceeded-event-to-kotlin-sdk

adds support for password_reset.succeeded event type


## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
