### PR TITLE
Add customAttributes field to SSO Profile

### DIFF
--- a/src/main/kotlin/com/workos/sso/models/Profile.kt
+++ b/src/main/kotlin/com/workos/sso/models/Profile.kt
@@ -18,6 +18,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param lastName The user's last name.
  * @param role The user's role based on group memberships.
  * @param groups The user's group memberships.
+ * @param customAttributes Object of key-value pairs containing mapped data from the Identity Provider.
  * @param rawAttributes Object of key-value pairs containing relevant user data from the Identity Provider.
  */
 data class Profile
@@ -63,6 +64,10 @@ data class Profile
   @JvmField
   @JsonProperty("groups")
   val groups: List<String>?,
+
+  @JvmField
+  @JsonProperty("custom_attributes")
+  val customAttributes: Map<String, Any>,
 
   @JvmField
   @JsonProperty("raw_attributes")

--- a/src/test/kotlin/com/workos/test/sso/SsoApiTest.kt
+++ b/src/test/kotlin/com/workos/test/sso/SsoApiTest.kt
@@ -175,7 +175,8 @@ class SsoApiTest : TestBase() {
           "role":{"slug":"admin"},
           "object": "profile",
           "organization_id": "org_01FJYCNTB6VC4K5R8BTF86286Q",
-          "raw_attributes": {"foo": "bar"}
+          "custom_attributes": {"license": "professional"},
+          "raw_attributes": {"foo": "bar", "license": "professional"}
         }
       }"""
     )
@@ -211,7 +212,8 @@ class SsoApiTest : TestBase() {
           "groups":["Admins", "Developers"],
           "object": "profile",
           "organization_id": "org_01FJYCNTB6VC4K5R8BTF86286Q",
-          "raw_attributes": {"foo": "bar", "groups":["Admins", "Developers"]}
+          "custom_attributes": {"license": "professional"},
+          "raw_attributes": {"foo": "bar", "groups":["Admins", "Developers"], "license": "professional"}
         }
       }"""
     )
@@ -247,7 +249,8 @@ class SsoApiTest : TestBase() {
           "role":{"slug":"admin"},
           "object": "profile",
           "organization_id": "org_01FJYCNTB6VC4K5R8BTF86286Q",
-          "raw_attributes": {"foo": "bar"}
+          "custom_attributes": {"license": "professional"},
+          "raw_attributes": {"foo": "bar", "license": "professional"}
         }
       }"""
     )
@@ -282,7 +285,8 @@ class SsoApiTest : TestBase() {
           "last_name": "Rundgren",
           "object": "profile",
           "organization_id": "org_01FJYCNTB6VC4K5R8BTF86286Q",
-          "raw_attributes": {"foo": "bar"}
+          "custom_attributes": {"license": "professional"},
+          "raw_attributes": {"foo": "bar", "license": "professional"}
         }
       }"""
     )
@@ -310,13 +314,15 @@ class SsoApiTest : TestBase() {
         "role":{"slug":"admin"},
         "object": "profile",
         "organization_id": "org_01FJYCNTB6VC4K5R8BTF86286Q",
-        "raw_attributes": {"foo": "foo_value"}
+        "custom_attributes": {"license": "professional"},
+        "raw_attributes": {"foo": "foo_value", "license": "professional"}
       }"""
     )
 
     val profile = workos.sso.getProfile("accessToken")
 
     assertEquals("prof_01DMC79VCBZ0NY2099737PSVF2", profile.id)
+    assertEquals("professional", profile.customAttributes.get("license"))
     assertEquals("foo_value", profile.rawAttributes.get("foo"))
   }
 


### PR DESCRIPTION
## Description
Add customAttributes field to SSO Profile.

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
