### PR TITLE
adding "deleting" to connectionState enums

### DIFF
--- a/src/main/kotlin/com/workos/sso/models/ConnectionState.kt
+++ b/src/main/kotlin/com/workos/sso/models/ConnectionState.kt
@@ -1,4 +1,4 @@
-cpackage com.workos.sso.models
+package com.workos.sso.models
 
 import com.fasterxml.jackson.annotation.JsonValue
 

--- a/src/main/kotlin/com/workos/sso/models/ConnectionState.kt
+++ b/src/main/kotlin/com/workos/sso/models/ConnectionState.kt
@@ -1,4 +1,4 @@
-package com.workos.sso.models
+cpackage com.workos.sso.models
 
 import com.fasterxml.jackson.annotation.JsonValue
 
@@ -12,6 +12,10 @@ enum class ConnectionState(@JsonValue val state: String) {
    * The connection is active and able to authenticate users.
    */
   Active("active"),
+  /**
+   * The connection has been deleted or is in a deleting status.
+   */
+  Draft("deleting"),
 
   /**
    * The connection has been created and requires configuration to be activated.

--- a/src/main/kotlin/com/workos/sso/models/ConnectionState.kt
+++ b/src/main/kotlin/com/workos/sso/models/ConnectionState.kt
@@ -15,7 +15,7 @@ enum class ConnectionState(@JsonValue val state: String) {
   /**
    * The connection has been deleted or is in a deleting status.
    */
-  Draft("deleting"),
+  Deleting("deleting"),
 
   /**
    * The connection has been created and requires configuration to be activated.


### PR DESCRIPTION
## Description
"deleting" was added to that connection status enums

Should fix #277 

## Documentation

n/a

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[ ] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
