### PR TITLE
Add warnings to FGA check and query responses

### DIFF
--- a/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/CheckResponse.kt
@@ -15,7 +15,10 @@ data class CheckResponse @JsonCreator constructor(
   val isImplicit: Boolean,
 
   @JsonProperty("debug_info")
-  val debugInfo: DebugInfo? = null
+  val debugInfo: DebugInfo? = null,
+
+  @JsonProperty("warnings")
+  val warnings: List<Warning>? = null
 ) {
   fun authorized(): Boolean {
     return this.result == CHECK_RESULT_AUTHORIZED

--- a/src/main/kotlin/com/workos/fga/models/QueryResponse.kt
+++ b/src/main/kotlin/com/workos/fga/models/QueryResponse.kt
@@ -11,5 +11,8 @@ data class QueryResponse
   val data: List<QueryResult>,
 
   @JsonProperty("list_metadata")
-  val listMetadata: ListMetadata
+  val listMetadata: ListMetadata,
+
+  @JsonProperty("warnings")
+  val warnings: List<Warning>? = null
 )

--- a/src/main/kotlin/com/workos/fga/models/Warning.kt
+++ b/src/main/kotlin/com/workos/fga/models/Warning.kt
@@ -1,0 +1,29 @@
+package com.workos.fga.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+import com.fasterxml.jackson.annotation.JsonSubTypes
+import com.fasterxml.jackson.annotation.JsonTypeInfo
+
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "code")
+@JsonSubTypes(
+    JsonSubTypes.Type(value = MissingContextKeysWarning::class, name = "missing_context_keys")
+)
+abstract class Warning @JsonCreator constructor(
+    @JsonProperty("code")
+    val code: String,
+
+    @JsonProperty("message")
+    val message: String
+)
+
+data class MissingContextKeysWarning @JsonCreator constructor(
+    @JsonProperty("code")
+    override val code: String,
+
+    @JsonProperty("message")
+    override val message: String,
+
+    @JsonProperty("keys")
+    val keys: List<String>
+) : Warning(code, message) 


### PR DESCRIPTION
Adds warnings field to the FGA check and query responses. Warning types include:

BaseWarning - catch all for warnings not supported by the current SDK version
MissingContextKeysWarning - missing context keys found while evaluating policies in the check / query request
