### PR TITLE
add support for custom scopes

### DIFF
--- a/src/main/kotlin/com/workos/usermanagement/builders/AuthorizationUrlOptionsBuilder.kt
+++ b/src/main/kotlin/com/workos/usermanagement/builders/AuthorizationUrlOptionsBuilder.kt
@@ -17,6 +17,7 @@ import java.lang.IllegalArgumentException
  * @param organizationId Used to initiate SSO for an organization. The value should be a WorkOS organization ID.
  * @param provider Name of the identity provider e.g. Authkit, GitHubOAuth, GoogleOAuth, or MicrosoftOAuth.
  * @param state User defined information to persist application data between redirects.
+ * @param providerScopes Additional OAuth scopes to request from the provider.
  */
 class AuthorizationUrlOptionsBuilder @JvmOverloads constructor(
   private val baseUrl: String,
@@ -28,7 +29,8 @@ class AuthorizationUrlOptionsBuilder @JvmOverloads constructor(
   private var screenHint: String? = null,
   private var organizationId: String? = null,
   private var provider: UserManagementProviderEnumType? = null,
-  private var state: String? = null
+  private var state: String? = null,
+  private var providerScopes: List<String>? = null
 ) {
   /**
    * Connection ID.
@@ -79,6 +81,15 @@ class AuthorizationUrlOptionsBuilder @JvmOverloads constructor(
   fun state(value: String) = apply { state = value }
 
   /**
+   * Additional OAuth scopes to request from the provider.
+   */
+  fun providerScopes(value: List<String>) = apply {
+    if (value.isNotEmpty()) {
+      providerScopes = value
+    }
+  }
+
+  /**
    * Generates the URL based on the given options.
    */
   fun build(): String {
@@ -103,6 +114,7 @@ class AuthorizationUrlOptionsBuilder @JvmOverloads constructor(
     if (organizationId != null) uriBuilder.addParameter("organization_id", organizationId)
     if (provider != null) uriBuilder.addParameter("provider", provider!!.type)
     if (state != null) uriBuilder.addParameter("state", state)
+    if (providerScopes != null) uriBuilder.addParameter("provider_scopes", providerScopes!!.joinToString(","))
 
     return uriBuilder.toString()
   }

--- a/src/main/kotlin/com/workos/usermanagement/models/Authentication.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/Authentication.kt
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty
  * @param accessToken A JWT containing information about the session.
  * @param refreshToken Exchange this token for a new access token.
  * @param impersonator An impersonation definition.
+ * @param oauthTokens OAuth tokens from third-party providers.
  */
 data class Authentication @JsonCreator constructor(
   @JsonProperty("user")
@@ -27,4 +28,7 @@ data class Authentication @JsonCreator constructor(
 
   @JsonProperty("impersonator")
   val impersonator: AuthenticationImpersonator? = null,
+
+  @JsonProperty("oauth_tokens")
+  val oauthTokens: OAuthTokens? = null,
 )

--- a/src/main/kotlin/com/workos/usermanagement/models/OAuthTokens.kt
+++ b/src/main/kotlin/com/workos/usermanagement/models/OAuthTokens.kt
@@ -1,0 +1,26 @@
+package com.workos.usermanagement.models
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonProperty
+
+/**
+ * OAuth tokens from third-party providers
+ *
+ * @param accessToken The access token from the third-party provider.
+ * @param refreshToken The refresh token from the third-party provider.
+ * @param expiresAt The timestamp when the access token expires.
+ * @param scopes The scopes granted to the access token.
+ */
+data class OAuthTokens @JsonCreator constructor(
+  @JsonProperty("access_token")
+  val accessToken: String,
+
+  @JsonProperty("refresh_token")
+  val refreshToken: String,
+
+  @JsonProperty("expires_at")
+  val expiresAt: Long,
+
+  @JsonProperty("scopes")
+  val scopes: List<String>,
+)


### PR DESCRIPTION
## Description
- adds support for the `oauth_tokens` object in the authenticate API response
- adds support for the new `provider_scopes` query parameter

## Documentation

Does this require changes to the WorkOS Docs? E.g. the [API Reference](https://workos.com/docs/reference) or code snippets need updates.

```
[X] Yes
```

If yes, link a related docs PR and add a docs maintainer as a reviewer. Their approval is required.
