### PR TITLE
feat: Add optional issuers check to session authentication

### DIFF
--- a/src/main/kotlin/com/workos/session/Session.kt
+++ b/src/main/kotlin/com/workos/session/Session.kt
@@ -163,6 +163,10 @@ sealed class RefreshSessionResult {
  * [authenticate] to validate the cookie and decode claims; [refresh] to
  * exchange the embedded refresh token for a new sealed session;
  * [getLogoutUrl] to derive the logout URL.
+ *
+ * Pass [issuers] to additionally require the access token's `iss` claim to
+ * match one of the given values. When null (the default) the issuer is not
+ * checked.
  */
 class SessionCookie
   @JvmOverloads
@@ -170,7 +174,8 @@ class SessionCookie
     private val userManagement: UserManagement,
     sessionData: String?,
     private var cookiePassword: String,
-    private val objectMapper: ObjectMapper = defaultObjectMapper()
+    private val objectMapper: ObjectMapper = defaultObjectMapper(),
+    private val issuers: List<String>? = null
   ) {
     init {
       require(cookiePassword.isNotEmpty()) { "cookiePassword is required" }
@@ -196,7 +201,7 @@ class SessionCookie
         return AuthenticateSessionResult.Failure(AuthenticateSessionFailureReason.INVALID_SESSION_COOKIE)
       }
 
-      if (!Jwks.isValidJwt(userManagement.workos, session.accessToken)) {
+      if (!Jwks.isValidJwt(userManagement.workos, session.accessToken, issuers)) {
         return AuthenticateSessionResult.Failure(AuthenticateSessionFailureReason.INVALID_JWT)
       }
 
@@ -319,17 +324,26 @@ class Session internal constructor(
 ) {
   private val objectMapper = defaultObjectMapper()
 
-  /** Build a [SessionCookie] handler for an inbound sealed-cookie value. */
+  /**
+   * Build a [SessionCookie] handler for an inbound sealed-cookie value.
+   *
+   * @param issuers accepted values for the access token's `iss` claim; when
+   *   null (the default) the issuer is not checked.
+   */
+  @JvmOverloads
   fun loadSealedSession(
     sessionData: String?,
-    cookiePassword: String
-  ): SessionCookie = SessionCookie(UserManagement(workos), sessionData, cookiePassword, objectMapper)
+    cookiePassword: String,
+    issuers: List<String>? = null
+  ): SessionCookie = SessionCookie(UserManagement(workos), sessionData, cookiePassword, objectMapper, issuers)
 
   /** Convenience: authenticate a sealed cookie in one call. */
+  @JvmOverloads
   fun authenticateWithSessionCookie(
     sessionData: String?,
-    cookiePassword: String
-  ): AuthenticateSessionResult = loadSealedSession(sessionData, cookiePassword).authenticate()
+    cookiePassword: String,
+    issuers: List<String>? = null
+  ): AuthenticateSessionResult = loadSealedSession(sessionData, cookiePassword, issuers).authenticate()
 
   /** Convenience: refresh a sealed cookie in one call. */
   @JvmOverloads
@@ -397,7 +411,8 @@ internal object Jwks {
 
   fun isValidJwt(
     workos: WorkOS,
-    accessToken: String
+    accessToken: String,
+    issuers: List<String>? = null
   ): Boolean {
     val clientId = workos.clientId ?: error("Missing client ID. Did you provide it when initializing WorkOS?")
     val processor =
@@ -409,8 +424,10 @@ internal object Jwks {
         }
       }
     return try {
-      processor.process(SignedJWT.parse(accessToken), null)
-      true
+      val claims = processor.process(SignedJWT.parse(accessToken), null)
+      if (issuers == null) return true
+      val iss = claims.issuer
+      iss != null && iss in issuers
     } catch (_: Exception) {
       false
     }

--- a/src/main/kotlin/com/workos/session/Session.kt
+++ b/src/main/kotlin/com/workos/session/Session.kt
@@ -175,11 +175,21 @@ class SessionCookie
     sessionData: String?,
     private var cookiePassword: String,
     private val objectMapper: ObjectMapper = defaultObjectMapper(),
-    private val issuers: List<String>? = null
+    issuers: List<String>?
   ) {
+    @JvmOverloads
+    constructor(
+      userManagement: UserManagement,
+      sessionData: String?,
+      cookiePassword: String,
+      objectMapper: ObjectMapper = defaultObjectMapper()
+    ) : this(userManagement, sessionData, cookiePassword, objectMapper, null)
+
     init {
       require(cookiePassword.isNotEmpty()) { "cookiePassword is required" }
     }
+
+    private val issuers: List<String>? = issuers?.toList()
 
     private var sessionData: String? = sessionData
 

--- a/src/main/kotlin/com/workos/session/Session.kt
+++ b/src/main/kotlin/com/workos/session/Session.kt
@@ -166,7 +166,12 @@ sealed class RefreshSessionResult {
  *
  * Pass [issuers] to additionally require the access token's `iss` claim to
  * match one of the given values. When null (the default) the issuer is not
- * checked.
+ * checked. The match is exact (case-sensitive string equality). The `iss`
+ * value WorkOS mints varies by environment — `https://api.workos.com`,
+ * `https://api.workos.com/user_management/<clientId>`, or a custom auth
+ * domain — so pass the precise value(s) your tokens actually carry. The
+ * issuer policy is applied by [authenticate] only; [refresh] does not
+ * validate the access token.
  */
 class SessionCookie
   @JvmOverloads
@@ -235,7 +240,8 @@ class SessionCookie
     /**
      * Exchange the embedded refresh token for a new access token, reseal the
      * updated session, and update this helper's state so subsequent
-     * [authenticate] calls see the new token.
+     * [authenticate] calls see the new token. The issuer policy is not
+     * applied here; it is enforced on [authenticate].
      */
     @JvmOverloads
     fun refresh(
@@ -338,7 +344,11 @@ class Session internal constructor(
    * Build a [SessionCookie] handler for an inbound sealed-cookie value.
    *
    * @param issuers accepted values for the access token's `iss` claim; when
-   *   null (the default) the issuer is not checked.
+   *   null (the default) the issuer is not checked. The match is exact
+   *   (case-sensitive). The `iss` value WorkOS mints varies by environment —
+   *   `https://api.workos.com`, `https://api.workos.com/user_management/<clientId>`,
+   *   or a custom auth domain — so pass the precise value(s) your tokens
+   *   actually carry.
    */
   @JvmOverloads
   fun loadSealedSession(
@@ -347,7 +357,16 @@ class Session internal constructor(
     issuers: List<String>? = null
   ): SessionCookie = SessionCookie(UserManagement(workos), sessionData, cookiePassword, objectMapper, issuers)
 
-  /** Convenience: authenticate a sealed cookie in one call. */
+  /**
+   * Convenience: authenticate a sealed cookie in one call.
+   *
+   * @param issuers accepted values for the access token's `iss` claim; when
+   *   null (the default) the issuer is not checked. The match is exact
+   *   (case-sensitive). The `iss` value WorkOS mints varies by environment —
+   *   `https://api.workos.com`, `https://api.workos.com/user_management/<clientId>`,
+   *   or a custom auth domain — so pass the precise value(s) your tokens
+   *   actually carry.
+   */
   @JvmOverloads
   fun authenticateWithSessionCookie(
     sessionData: String?,

--- a/src/test/kotlin/com/workos/session/SessionTest.kt
+++ b/src/test/kotlin/com/workos/session/SessionTest.kt
@@ -131,6 +131,46 @@ class SessionTest : TestBase() {
   }
 
   @Test
+  fun `authenticate ignores the issuer when none is configured`() {
+    val result = authenticateWithIssuers(issuers = null, iss = "https://issuer.example")
+    assertTrue(result is AuthenticateSessionResult.Success)
+  }
+
+  @Test
+  fun `authenticate accepts a token whose iss matches a configured issuer`() {
+    val result = authenticateWithIssuers(listOf("https://issuer.example"), iss = "https://issuer.example")
+    assertTrue(result is AuthenticateSessionResult.Success)
+  }
+
+  @Test
+  fun `authenticate returns INVALID_JWT when iss does not match the configured issuer`() {
+    val result = authenticateWithIssuers(listOf("https://issuer.example"), iss = "https://other.example")
+    val failure = result as AuthenticateSessionResult.Failure
+    assertEquals(AuthenticateSessionFailureReason.INVALID_JWT, failure.reason)
+  }
+
+  @Test
+  fun `authenticate returns INVALID_JWT when iss is absent and an issuer is configured`() {
+    val result = authenticateWithIssuers(listOf("https://issuer.example"), iss = null)
+    val failure = result as AuthenticateSessionResult.Failure
+    assertEquals(AuthenticateSessionFailureReason.INVALID_JWT, failure.reason)
+  }
+
+  @Test
+  fun `authenticate accepts any issuer in the configured list`() {
+    val issuers = listOf("https://api.workos.com", "https://api.workos.com/user_management/client_123")
+    assertTrue(authenticateWithIssuers(issuers, iss = issuers[0]) is AuthenticateSessionResult.Success)
+    assertTrue(authenticateWithIssuers(issuers, iss = issuers[1]) is AuthenticateSessionResult.Success)
+  }
+
+  @Test
+  fun `authenticate rejects every token when the issuer list is empty`() {
+    val result = authenticateWithIssuers(emptyList(), iss = "https://issuer.example")
+    val failure = result as AuthenticateSessionResult.Failure
+    assertEquals(AuthenticateSessionFailureReason.INVALID_JWT, failure.reason)
+  }
+
+  @Test
   fun `refresh exchanges the token, reseals, and returns success`() {
     val workos = workOSForTest()
     val rsaKey = RSAKeyGenerator(2048).keyID("k1").keyUse(KeyUse.SIGNATURE).generate()
@@ -254,6 +294,19 @@ class SessionTest : TestBase() {
     }
   }
 
+  private fun authenticateWithIssuers(
+    issuers: List<String>?,
+    iss: String?
+  ): AuthenticateSessionResult {
+    val workos = workOSForTest()
+    val rsaKey = RSAKeyGenerator(2048).keyID("k1").keyUse(KeyUse.SIGNATURE).generate()
+    stubJwks(clientIdOf(workos), jwksJson(rsaKey))
+    val accessToken = signJwt(rsaKey, sessionId = "sess_iss", orgId = null, issuer = iss)
+    val cookieJson = mapper.writeValueAsString(mapOf("accessToken" to accessToken, "refreshToken" to "r"))
+    val sealed = Iron.seal(cookieJson, cookiePassword)
+    return workos.session.authenticateWithSessionCookie(sealed, cookiePassword, issuers)
+  }
+
   private fun stubJwks(
     clientId: String,
     jwksJson: String
@@ -272,18 +325,19 @@ class SessionTest : TestBase() {
   private fun signJwt(
     key: RSAKey,
     sessionId: String,
-    orgId: String?
+    orgId: String?,
+    issuer: String? = "https://api.workos.com/"
   ): String {
     val claimsBuilder =
       JWTClaimsSet
         .Builder()
-        .issuer("https://api.workos.com/")
         .subject("user_1")
         .jwtID(UUID.randomUUID().toString())
         .issueTime(Date())
         .expirationTime(Date(System.currentTimeMillis() + 60_000))
         .claim("sid", sessionId)
     if (orgId != null) claimsBuilder.claim("org_id", orgId)
+    if (issuer != null) claimsBuilder.issuer(issuer)
     val jwt =
       SignedJWT(
         JWSHeader.Builder(JWSAlgorithm.RS256).keyID(key.keyID).build(),


### PR DESCRIPTION
## Summary

Lets apps opt in to validating the `iss` claim of session access tokens. Part of the cross-SDK rollout started in workos/authkit-react-router#83 (see also workos/workos-node#1694, workos/workos-python#725, workos/workos-ruby#552, workos/workos-php#440). Default behavior is unchanged: with no issuers passed, `iss` is not checked, exactly as before.

`WorkOS`'s constructor lives in generated `WorkOS.kt` (oagen), so the option is a per-call parameter on the hand-maintained session helpers rather than client config:

```kotlin
fun Session.loadSealedSession(sessionData: String?, cookiePassword: String,
    issuers: List<String>? = null): SessionCookie
fun Session.authenticateWithSessionCookie(sessionData: String?, cookiePassword: String,
    issuers: List<String>? = null): AuthenticateSessionResult

class SessionCookie(userManagement, sessionData, cookiePassword,
    objectMapper = defaultObjectMapper(), issuers: List<String>?) {
  // pre-existing shape, kept as a secondary constructor -> issuers = null
  @JvmOverloads constructor(userManagement, sessionData, cookiePassword,
    objectMapper = defaultObjectMapper())
}
```

`Jwks.isValidJwt` keeps its existing Nimbus `DefaultJWTProcessor` (signature + default `exp`/`nbf` checks) and, when `issuers != null`, additionally requires `claims.issuer` to be non-null and contained in the list. An explicit empty list fails closed (rejects every token). Mismatches surface as the existing `AuthenticateSessionFailureReason.INVALID_JWT`. `refresh()` does not verify a JWT and is unchanged. `SessionCookie` snapshots the list (`issuers?.toList()`) so caller mutation can't change the policy later.

```kotlin
workos.session.authenticateWithSessionCookie(
  cookie, password,
  issuers = listOf("https://api.workos.com/user_management/$clientId", "https://auth.example.com")
)
```

Binary compatibility: the old `SessionCookie` JVM constructors — `(UM, String, String)`, `(UM, String, String, ObjectMapper)` and the synthetic `$default` one — are unchanged (verified with `javap`); `loadSealedSession`/`authenticateWithSessionCookie` gain `@JvmOverloads` so their two-arg descriptors also remain.

Tests: `./script/ci` (ktlint, full test suite, Dokka) passes. New `SessionTest` cases cover unset, matching, mismatched, absent `iss`, list, and empty list.

Link to Devin session: https://app.devin.ai/sessions/0ee38e859a9849658a7cdb2d215d89a6
Open in Devin Desktop: https://app.devin.ai/desktop/session/0ee38e859a9849658a7cdb2d215d89a6?variant=devin
Requested by: @m0tzy