### PR TITLE
fix(http): Prevent dot segments from retargeting requests

### DIFF
--- a/src/main/kotlin/com/workos/common/http/BaseClient.kt
+++ b/src/main/kotlin/com/workos/common/http/BaseClient.kt
@@ -226,12 +226,16 @@ open class BaseClient(
     idempotencyKey: String?
   ): Request {
     val effectiveBase = config.requestOptions?.baseUrl ?: apiBaseUrl
-    val urlBuilder =
+    val url =
       effectiveBase
         .trimEnd('/')
         .let { "$it${config.path}" }
         .toHttpUrl()
-        .newBuilder()
+    require(url.encodedPath == config.path) {
+      "Resolved URL path must match RequestConfig.path; apiBaseUrl/baseUrl must have no path prefix, " +
+        "and the request path must be encoded without '.' or '..' segments"
+    }
+    val urlBuilder = url.newBuilder()
     for ((name, value) in config.queryParams) {
       urlBuilder.addQueryParameter(name, value)
     }

--- a/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
+++ b/src/main/kotlin/com/workos/common/http/UrlEncoding.kt
@@ -21,9 +21,15 @@ import java.net.URLEncoder
  * Percent-encode [value] for safe interpolation as a single URI path segment
  * per RFC 3986 §3.3. All reserved characters (`/`, `?`, `#`, etc.) and
  * sub-delims that could change parsing are encoded; `~` and other unreserved
- * characters are left alone.
+ * characters are left alone within non-dot segments.
+ *
+ * @throws IllegalArgumentException if [value] is empty, `.` or `..`.
  */
 fun encodePathSegment(value: String): String {
+  // OkHttp removes dot segments even when the dots are percent-encoded.
+  require(value.isNotEmpty() && value != "." && value != "..") {
+    "Path segment must not be empty, '.' or '..'"
+  }
   val formEncoded = URLEncoder.encode(value, Charsets.UTF_8)
   val out = StringBuilder(formEncoded.length)
   var i = 0

--- a/src/test/kotlin/com/workos/common/http/BaseClientPathSafetyTest.kt
+++ b/src/test/kotlin/com/workos/common/http/BaseClientPathSafetyTest.kt
@@ -1,0 +1,92 @@
+// @oagen-ignore-file
+package com.workos.common.http
+
+import com.github.tomakehurst.wiremock.client.WireMock.aResponse
+import com.github.tomakehurst.wiremock.client.WireMock.any
+import com.github.tomakehurst.wiremock.client.WireMock.anyUrl
+import com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import com.workos.groups.Groups
+import com.workos.test.TestBase
+import okhttp3.OkHttpClient
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Test
+
+class BaseClientPathSafetyTest : TestBase() {
+  @Test
+  fun `group deletion rejects empty and dot identifiers without sending requests`() {
+    wireMockRule.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(204)))
+    val groups = Groups(createWorkOSClient())
+    for (id in listOf("..", ".", "")) {
+      assertThrows(IllegalArgumentException::class.java) { groups.deleteOrganizationGroup("org_123", id) }
+      assertThrows(IllegalArgumentException::class.java) { groups.deleteOrganizationGroup(id, "group_123") }
+      assertThrows(IllegalArgumentException::class.java) { groups.deleteOrganizationMembership("org_123", id, "om_123") }
+      assertThrows(IllegalArgumentException::class.java) { groups.deleteOrganizationMembership("org_123", "group_123", id) }
+    }
+    assertEquals(0, wireMockRule.allServeEvents.size)
+  }
+
+  @Test
+  fun `safe group identifiers retain their encoded path on the wire`() {
+    wireMockRule.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(204)))
+    val groups = Groups(createWorkOSClient())
+    val ids = listOf("group_123", "group.name", "...", "%2e", "%2E%2e", ".%2e", "%2e.", "../admin", "..\\admin", "a?b#c", "a b+café")
+    for (id in ids) {
+      val path = "/organizations/org_123/groups/${encodePathSegment(id)}"
+      groups.deleteOrganizationGroup("org_123", id)
+      wireMockRule.verify(1, deleteRequestedFor(urlEqualTo(path)))
+    }
+    assertEquals(ids.size, wireMockRule.allServeEvents.size)
+  }
+
+  @Test
+  fun `raw request paths reject literal and encoded dot segments before transport`() {
+    wireMockRule.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(204)))
+    val client = createWorkOSClient().baseClient
+    for (segment in listOf(".", "..", "%2e", "%2E", "%2e%2e", "%2E%2E", "%2e%2E", ".%2e", "%2E.")) {
+      for (suffix in listOf("", "/organization-memberships/om_123")) {
+        val path = "/organizations/org_123/groups/$segment$suffix"
+        assertThrows(IllegalArgumentException::class.java, { client.requestVoid(RequestConfig("DELETE", path)) }, path)
+      }
+    }
+    assertEquals(0, wireMockRule.allServeEvents.size)
+  }
+
+  @Test
+  fun `raw request paths reject other canonicalization changes before transport`() {
+    wireMockRule.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(204)))
+    val client = createWorkOSClient().baseClient
+    for (path in listOf("/groups/a\\..\\..", "/groups/a?b", "/groups/a#b", "/groups/a b", "/groups/a\nb")) {
+      assertThrows(IllegalArgumentException::class.java, { client.requestVoid(RequestConfig("DELETE", path)) }, path)
+    }
+    assertEquals(0, wireMockRule.allServeEvents.size)
+  }
+
+  @Test
+  fun `base URL path prefixes are rejected for client and per-request configuration`() {
+    wireMockRule.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(204)))
+    val client = BaseClient("sk_test", "${wireMockRule.baseUrl()}/prefix", OkHttpClient())
+    assertThrows(IllegalArgumentException::class.java) { client.requestVoid(RequestConfig("DELETE", "/groups/group_123")) }
+    assertThrows(IllegalArgumentException::class.java) {
+      createWorkOSClient().baseClient.requestVoid(
+        RequestConfig("DELETE", "/groups/group_123", requestOptions = RequestOptions(baseUrl = "${wireMockRule.baseUrl()}/prefix"))
+      )
+    }
+    assertEquals(0, wireMockRule.allServeEvents.size)
+  }
+
+  @Test
+  fun `trailing base URL slash and query parameters preserve intended path`() {
+    wireMockRule.stubFor(any(anyUrl()).willReturn(aResponse().withStatus(204)))
+    createWorkOSClient().baseClient.requestVoid(
+      RequestConfig(
+        "DELETE",
+        "/groups/group_123",
+        queryParams = listOf("cursor" to "../a?b#c"),
+        requestOptions = RequestOptions(baseUrl = "${wireMockRule.baseUrl()}/")
+      )
+    )
+    wireMockRule.verify(1, deleteRequestedFor(urlEqualTo("/groups/group_123?cursor=..%2Fa%3Fb%23c")))
+  }
+}

--- a/src/test/kotlin/com/workos/common/http/EncodePathSegmentTest.kt
+++ b/src/test/kotlin/com/workos/common/http/EncodePathSegmentTest.kt
@@ -2,6 +2,7 @@
 package com.workos.common.http
 
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
 
 class EncodePathSegmentTest {
@@ -38,11 +39,22 @@ class EncodePathSegmentTest {
   }
 
   @Test
+  fun `rejects empty and dot segments`() {
+    for (value in listOf("", ".", "..")) {
+      assertThrows(IllegalArgumentException::class.java, { encodePathSegment(value) }, "value: '$value'")
+    }
+  }
+
+  @Test
+  fun `preserves dots within identifiers and encodes literal percent escapes`() {
+    assertEquals("...", encodePathSegment("..."))
+    assertEquals("group.name", encodePathSegment("group.name"))
+    assertEquals("%252e%252E", encodePathSegment("%2e%2E"))
+    assertEquals(".%252e", encodePathSegment(".%2e"))
+  }
+
+  @Test
   fun `prevents path traversal by encoding slashes`() {
-    // A literal `..` is not by itself dangerous (the server resolves it as a
-    // segment), but any embedded `/` must be encoded so a malicious id
-    // cannot escape its own segment.
-    assertEquals("..", encodePathSegment(".."))
     assertEquals("..%2Fadmin", encodePathSegment("../admin"))
     assertEquals("foo%2F..%2Fbar", encodePathSegment("foo/../bar"))
   }


### PR DESCRIPTION
## Summary
- Reject empty, `.` and `..` identifiers centrally in `encodePathSegment`, preventing destructive requests from escaping their intended resource path (VULN-1247).
- Verify OkHttp's parsed encoded path matches `RequestConfig.path` before transport, including literal and percent-encoded dot segments. Base URLs with path prefixes now fail explicitly.
- Replace the misleading dot-segment assertion and add WireMock regressions covering group and membership deletion, unchanged safe identifiers, raw paths, base URLs, and query parameters.
- Verified the vulnerability against main (`d9bdf49`): five regression tests fail with main's HTTP implementation. With the fix, all 583 tests pass; `JAVA_HOME=$(/usr/libexec/java_home -v 17) ./gradlew build test ktlintCheck --info` succeeds.
