### PR TITLE
fix(http): Redact sensitive query values in 404 errors

### DIFF
--- a/src/main/kotlin/com/workos/common/http/BaseClient.kt
+++ b/src/main/kotlin/com/workos/common/http/BaseClient.kt
@@ -328,7 +328,7 @@ open class BaseClient(
   }
 
   /**
-   * Redact bearer-equivalent path segments before they get embedded in
+   * Redact bearer-equivalent path segments and sensitive query values before they get embedded in
    * exception messages or downstream logs (security finding #51, mirrors
    * the Ruby `base_client.rb` redaction list from #44).
    *
@@ -338,16 +338,19 @@ open class BaseClient(
    * Anyone with read access to a 404's exception trail would otherwise be
    * able to replay the token. We replace the secret segment with
    * `[REDACTED]` while keeping the route prefix intact for debuggability.
+   * Query values for `code`, `token`, and `client_secret` are also redacted,
+   * preserving non-sensitive parameters.
    */
   private fun redactSensitivePath(url: String): String {
     var redacted = url
     for (pattern in SENSITIVE_PATH_PATTERNS) {
       redacted = pattern.replace(redacted, "$1[REDACTED]")
     }
-    return redacted
+    return SENSITIVE_QUERY_PATTERN.replace(redacted, "$1[REDACTED]")
   }
 
   private companion object {
+    private val SENSITIVE_QUERY_PATTERN = Regex("([?&](?:code|token|client_secret)=)[^&#]*")
     private val SENSITIVE_PATH_PATTERNS: List<Regex> =
       listOf(
         Regex("(/user_management/invitations/by_token/)[^/?#]+"),

--- a/src/test/kotlin/com/workos/common/http/BaseClientErrorMappingTest.kt
+++ b/src/test/kotlin/com/workos/common/http/BaseClientErrorMappingTest.kt
@@ -91,6 +91,7 @@ class BaseClientErrorMappingTest : TestBase() {
   fun `404 maps to NotFoundException`() {
     val ex = runErrorCase<NotFoundException>(404, """{"message": "Not here"}""")
     assertEquals("Not here", ex.message)
+    assertEquals("${wireMockRule.baseUrl()}/errors", ex.path)
   }
 
   /**
@@ -166,6 +167,51 @@ class BaseClientErrorMappingTest : TestBase() {
       path = "/user_management/magic_auth/super-secret-magic-000",
       redactedPath = "/user_management/magic_auth/[REDACTED]"
     )
+  }
+
+  @Test
+  fun `404 redacts sensitive query values while preserving non-sensitive params`() {
+    stubResponse("GET", "/errors", 404)
+    val queryParams =
+      listOf(
+        "code" to "super-secret-code",
+        "domain" to "example.com",
+        "token" to "super-secret-token",
+        "client_secret" to "super-secret-client-secret",
+        "code" to "another-secret-code"
+      )
+    val client = createWorkOSClient()
+    val ex =
+      assertThrows(NotFoundException::class.java) {
+        client.baseClient.request(
+          RequestConfig(method = "GET", path = "/errors", queryParams = queryParams),
+          Map::class.java
+        )
+      }
+    assertEquals(
+      "${wireMockRule.baseUrl()}/errors?code=[REDACTED]&domain=example.com" +
+        "&token=[REDACTED]&client_secret=[REDACTED]&code=[REDACTED]",
+      ex.path
+    )
+    for ((name, value) in queryParams) {
+      if (name != "domain") {
+        assertTrue(!ex.path!!.contains(value), "exception path leaked sensitive query value")
+      }
+    }
+  }
+
+  @Test
+  fun `404 leaves non-sensitive query params unredacted`() {
+    stubResponse("GET", "/errors", 404)
+    val client = createWorkOSClient()
+    val ex =
+      assertThrows(NotFoundException::class.java) {
+        client.baseClient.request(
+          RequestConfig(method = "GET", path = "/errors", queryParams = listOf("domain" to "example.com")),
+          Map::class.java
+        )
+      }
+    assertEquals("${wireMockRule.baseUrl()}/errors?domain=example.com", ex.path)
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Redact `code`, `token`, and `client_secret` query values in `NotFoundException.path` so 404 exception metadata does not leak credentials into downstream logs.
- Preserve non-sensitive query parameters and existing path-token redaction for debuggability.
- Cover all three sensitive keys, repeated keys, mixed/non-sensitive parameters, and query-less URLs with regression assertions.
- Deliver only the hand-maintained defense-in-depth portion of [VULN-1278](https://linear.app/workos/issue/VULN-1278); this PR does **not** fix the primary SSO authorization-code-in-URL leak.

## Upstream follow-up required
`SSO.getProfileAndToken` on current `main` still sends `code` in both the query string and JSON body. `SSO.kt` and `SSOTest.kt` are oagen-generated, have no hand-maintainable fences, and cannot be hand-edited under the repository's generated-file policy. The body-only request fix and no-query-string regression assertion must land through the upstream OpenAPI spec/oagen pipeline (Kotlin emitter in `workos/oagen-emitters`) and regeneration. This is tracked separately on VULN-1278; the upstream follow-up has already been noted on Linear. Do not consider the vulnerability resolved by this PR alone.

## Validation
- `./gradlew test --tests 'com.workos.common.http.BaseClientErrorMappingTest'`
- `./gradlew check` — 668 tests passed, no failures/errors/skips; ktlint passed.
- `./gradlew build` — passed, including Javadoc generation.
- Only the two `@oagen-ignore-file` HTTP client files are included; no generated files or manifest changes.
