### PR TITLE
fix(session): Reject malformed seal encodings

### DIFF
--- a/src/main/kotlin/com/workos/session/Iron.kt
+++ b/src/main/kotlin/com/workos/session/Iron.kt
@@ -113,23 +113,28 @@ object Iron {
         expiration
       ).joinToString("*")
 
-    val intKey = deriveKey(password, intSaltHex, INT_KEY_BITS / 8)
-    val expectedHmac = hmacSha256(intKey, macBase.toByteArray(Charsets.UTF_8))
-    val givenHmac = URL_DECODER.decode(hmacB64)
-    if (!constantTimeEquals(expectedHmac, givenHmac)) {
-      throw IronException("Bad hmac value")
-    }
+    try {
+      val intKey = deriveKey(password, intSaltHex, INT_KEY_BITS / 8)
+      val expectedHmac = hmacSha256(intKey, macBase.toByteArray(Charsets.UTF_8))
+      val givenHmac = URL_DECODER.decode(hmacB64)
+      if (!constantTimeEquals(expectedHmac, givenHmac)) {
+        throw IronException("Bad hmac value")
+      }
 
-    if (expiration.isNotEmpty()) {
-      val exp = expiration.toLongOrNull() ?: throw IronException("Invalid expiration")
-      if (nowMillis() > exp) throw IronException("Expired seal")
-    }
+      if (expiration.isNotEmpty()) {
+        val exp = expiration.toLongOrNull() ?: throw IronException("Invalid expiration")
+        if (nowMillis() > exp) throw IronException("Expired seal")
+      }
 
-    val encKey = deriveKey(password, encSaltHex, ENC_KEY_BITS / 8)
-    val iv = URL_DECODER.decode(ivB64)
-    val ct = URL_DECODER.decode(ctB64)
-    val plaintext = aesCbcDecrypt(ct, encKey, iv)
-    return String(plaintext, Charsets.UTF_8)
+      val encKey = deriveKey(password, encSaltHex, ENC_KEY_BITS / 8)
+      val iv = URL_DECODER.decode(ivB64)
+      val ct = URL_DECODER.decode(ctB64)
+      val plaintext = aesCbcDecrypt(ct, encKey, iv)
+      return String(plaintext, Charsets.UTF_8)
+    } catch (_: IllegalArgumentException) {
+      // Invalid base64 or salt input is a bad seal, not a password configuration error.
+      throw IronException("Invalid seal encoding")
+    }
   }
 
   private fun randomBytes(length: Int): ByteArray = ByteArray(length).also { random.nextBytes(it) }

--- a/src/test/kotlin/com/workos/session/IronTest.kt
+++ b/src/test/kotlin/com/workos/session/IronTest.kt
@@ -5,6 +5,11 @@ import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotEquals
 import org.junit.jupiter.api.Assertions.assertThrows
 import org.junit.jupiter.api.Test
+import java.util.Base64
+import javax.crypto.Mac
+import javax.crypto.SecretKeyFactory
+import javax.crypto.spec.PBEKeySpec
+import javax.crypto.spec.SecretKeySpec
 
 class IronTest {
   private val password = "this-is-at-least-thirty-two-chars!"
@@ -57,6 +62,51 @@ class IronTest {
   }
 
   @Test
+  fun `unseal rejects malformed base64 hmac with IronException`() {
+    for (hmac in listOf("!!", "A", "ab=c")) {
+      val ex = assertThrows(IronException::class.java) { Iron.unseal("Fe26.2*1*aa*bb*cc**dd*$hmac", password) }
+      assertEquals("Invalid seal encoding", ex.message)
+    }
+  }
+
+  @Test
+  fun `unseal rejects authenticated malformed base64 iv and ciphertext with IronException`() {
+    for (field in listOf(3, 4)) {
+      for (encoding in listOf("!!", "A", "ab=c")) {
+        val parts = Iron.seal("payload", password).split("*").toMutableList()
+        parts[field] = encoding
+        val ex = assertThrows(IronException::class.java) { Iron.unseal(resign(parts), password) }
+        assertEquals("Invalid seal encoding", ex.message)
+      }
+    }
+  }
+
+  @Test
+  fun `unseal rejects an empty integrity salt with IronException`() {
+    val parts = Iron.seal("payload", password).split("*").toMutableList()
+    parts[6] = ""
+    val ex = assertThrows(IronException::class.java) { Iron.unseal(parts.joinToString("*"), password) }
+    assertEquals("Invalid seal encoding", ex.message)
+  }
+
+  @Test
+  fun `unseal rejects an authenticated empty encryption salt with IronException`() {
+    val parts = Iron.seal("payload", password).split("*").toMutableList()
+    parts[2] = ""
+    val ex = assertThrows(IronException::class.java) { Iron.unseal(resign(parts), password) }
+    assertEquals("Invalid seal encoding", ex.message)
+  }
+
+  @Test
+  fun `unseal still rejects short passwords with IllegalArgumentException`() {
+    val ex =
+      assertThrows(IllegalArgumentException::class.java) {
+        Iron.unseal("Fe26.2*1*aa*bb*cc**dd*!!", "too-short")
+      }
+    assertEquals("Password must be at least 32 characters", ex.message)
+  }
+
+  @Test
   fun `seal rejects short passwords`() {
     assertThrows(IllegalArgumentException::class.java) { Iron.seal("x", "too-short") }
   }
@@ -67,6 +117,17 @@ class IronTest {
     Thread.sleep(10)
     val ex = assertThrows(IronException::class.java) { Iron.unseal(sealed, password) }
     assert(ex.message!!.contains("Expired"))
+  }
+
+  // Recompute the HMAC so malformed encrypted fields reach their decoding paths.
+  private fun resign(parts: MutableList<String>): String {
+    val spec = PBEKeySpec(password.toCharArray(), parts[6].toByteArray(Charsets.UTF_8), 1, 256)
+    val key = SecretKeyFactory.getInstance("PBKDF2WithHmacSHA1").generateSecret(spec).encoded
+    val mac = Mac.getInstance("HmacSHA256")
+    mac.init(SecretKeySpec(key, "HmacSHA256"))
+    val hmac = mac.doFinal(parts.take(6).joinToString("*").toByteArray(Charsets.UTF_8))
+    parts[7] = Base64.getUrlEncoder().withoutPadding().encodeToString(hmac)
+    return parts.joinToString("*")
   }
 
   @Test

--- a/src/test/kotlin/com/workos/session/SessionTest.kt
+++ b/src/test/kotlin/com/workos/session/SessionTest.kt
@@ -72,6 +72,29 @@ class SessionTest : TestBase() {
   }
 
   @Test
+  fun `authenticate returns INVALID_SESSION_COOKIE for malformed base64`() {
+    val workos = workOSForTest()
+    val result = workos.session.authenticateWithSessionCookie("Fe26.2*1*aa*bb*cc**dd*!!", cookiePassword)
+    val failure = result as AuthenticateSessionResult.Failure
+    assertEquals(AuthenticateSessionFailureReason.INVALID_SESSION_COOKIE, failure.reason)
+  }
+
+  @Test
+  fun `refresh returns INVALID_SESSION_COOKIE for malformed base64`() {
+    val workos = workOSForTest()
+    val helper = workos.session.loadSealedSession("Fe26.2*1*aa*bb*cc**dd*!!", cookiePassword)
+    val failure = helper.refresh() as RefreshSessionResult.Failure
+    assertEquals(RefreshSessionFailureReason.INVALID_SESSION_COOKIE, failure.reason)
+  }
+
+  @Test
+  fun `unsealData returns an empty map for malformed base64`() {
+    val workos = workOSForTest()
+    val out = workos.session.unsealData("Fe26.2*1*aa*bb*cc**dd*!!", cookiePassword)
+    assertTrue(out.isEmpty())
+  }
+
+  @Test
   fun `authenticate succeeds for a valid session cookie against a real JWKS`() {
     val workos = workOSForTest()
     val rsaKey = RSAKeyGenerator(2048).keyID("k1").keyUse(KeyUse.SIGNATURE).generate()


### PR DESCRIPTION
## Summary

- Convert malformed base64 and invalid salt input into `IronException("Invalid seal encoding")`, preventing malformed cookies from escaping session helpers as server errors.
- Preserve short-password `IllegalArgumentException`s and existing HMAC verification order; callers do not need broader exception handling.
- Add regressions for malformed HMAC, authenticated IV/ciphertext, empty salts, and the authenticate, refresh, and unsealData failure contracts.
- Verified against `origin/main`: seven regression tests fail before the fix. With the fix, all 583 tests pass and `./gradlew build test ktlintCheck --info` succeeds.

Addresses [VULN-1273](https://linear.app/workos/issue/VULN-1273/f057-low-malformed-base64-in-sealed-cookie-throws).
