### PR TITLE
fix(session): Validate Iron token password ID

### DIFF
--- a/src/main/kotlin/com/workos/session/Iron.kt
+++ b/src/main/kotlin/com/workos/session/Iron.kt
@@ -95,6 +95,7 @@ object Iron {
     val parts = sealed.split("*")
     if (parts.size != 8) throw IronException("Incorrect number of sealed components")
     val prefix = parts[0]
+    val passwordId = parts[1]
     val encSaltHex = parts[2]
     val ivB64 = parts[3]
     val ctB64 = parts[4]
@@ -102,11 +103,12 @@ object Iron {
     val intSaltHex = parts[6]
     val hmacB64 = parts[7]
     if (prefix != MAC_PREFIX) throw IronException("Wrong mac prefix")
+    if (passwordId != PASSWORD_ID) throw IronException("Unknown password id")
 
     val macBase =
       listOf(
         MAC_PREFIX,
-        PASSWORD_ID,
+        passwordId,
         encSaltHex,
         ivB64,
         ctB64,

--- a/src/test/kotlin/com/workos/session/IronTest.kt
+++ b/src/test/kotlin/com/workos/session/IronTest.kt
@@ -45,6 +45,18 @@ class IronTest {
   }
 
   @Test
+  fun `unseal rejects a seal whose password id was tampered with`() {
+    val sealed = Iron.seal("payload", password)
+    for (passwordId in listOf("2", "ZZZ", "")) {
+      val parts = sealed.split("*").toMutableList()
+      parts[1] = passwordId
+      val bad = parts.joinToString("*")
+      val ex = assertThrows(IronException::class.java, { Iron.unseal(bad, password) }, "Password ID: '$passwordId'")
+      assertEquals("Unknown password id", ex.message)
+    }
+  }
+
+  @Test
   fun `unseal rejects the wrong password`() {
     val sealed = Iron.seal("payload", password)
     val otherPassword = "a-different-password-at-least-32chars"


### PR DESCRIPTION
## Summary
- Reject unsupported password IDs with `IronException` before authentication or decryption to prevent token malleability.
- Build the HMAC base from the parsed password ID instead of silently substituting `1`.
- Cover numeric, arbitrary, and empty password ID mutations while retaining round-trip and iron-webcrypto fixture compatibility.

Addresses [VULN-1269](https://linear.app/workos/issue/VULN-1269).

## Validation
- `./gradlew test --info`
- `./gradlew build ktlintCheck test --rerun-tasks` — 576 tests passed, including all 10 Iron tests; build and lint passed.
- `git diff --check`
